### PR TITLE
[SCRUM-25] Add basic admin-side membership table

### DIFF
--- a/frontend/app/(admin)/dashboard/memberships/page.tsx
+++ b/frontend/app/(admin)/dashboard/memberships/page.tsx
@@ -8,8 +8,26 @@ export default function AdminMembershipsPage() {
       </header>
 
       <main>
-        <table>
+        <table className="overflow-x-auto rounded border border-gray-300">
+          <tbody className="min-w-full">
+            <tr className="border-b border-gray-200">
+              <td className="px-4 py-2">col 1</td>
+              <td className="px-4 py-2">col 2</td>
+              <td className="px-4 py-2">col 3</td>
+              <td className="px-4 py-2">col 4</td>
+              <td className="px-4 py-2">col 5</td>
+              <td className="px-4 py-2">col 6</td>
+            </tr>
 
+            <tr className="border-b border-gray-200">
+              <td className="px-4 py-2">col 1</td>
+              <td className="px-4 py-2">col 2</td>
+              <td className="px-4 py-2">col 3</td>
+              <td className="px-4 py-2">col 4</td>
+              <td className="px-4 py-2">col 5</td>
+              <td className="px-4 py-2">col 6</td>
+            </tr>
+          </tbody>
         </table>
       </main>
     </div>

--- a/frontend/app/(admin)/dashboard/memberships/page.tsx
+++ b/frontend/app/(admin)/dashboard/memberships/page.tsx
@@ -6,6 +6,12 @@ export default function AdminMembershipsPage() {
       <header className="mb-6">
         <h1>View Memberships</h1>
       </header>
+
+      <main>
+        <table>
+
+        </table>
+      </main>
     </div>
   );
 }

--- a/frontend/app/(admin)/dashboard/memberships/page.tsx
+++ b/frontend/app/(admin)/dashboard/memberships/page.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function AdminMembershipsPage() {
+  return(
+    <div>
+      <header>
+        <h1>Title</h1>
+      </header>
+    </div>
+  );
+}

--- a/frontend/app/(admin)/dashboard/memberships/page.tsx
+++ b/frontend/app/(admin)/dashboard/memberships/page.tsx
@@ -4,7 +4,7 @@ export default function AdminMembershipsPage() {
   return(
     <div>
       <header>
-        <h1>Title</h1>
+        <h1>View Memberships</h1>
       </header>
     </div>
   );

--- a/frontend/app/(admin)/dashboard/memberships/page.tsx
+++ b/frontend/app/(admin)/dashboard/memberships/page.tsx
@@ -2,8 +2,8 @@ import React from "react";
 
 export default function AdminMembershipsPage() {
   return(
-    <div>
-      <header>
+    <div className="p-6">
+      <header className="mb-6">
         <h1>View Memberships</h1>
       </header>
     </div>


### PR DESCRIPTION
## What does this PR do?
Adds a very basic table to the admin membership page, with the expected number of columns.
<img width="520" height="233" alt="image" src="https://github.com/user-attachments/assets/ef6e2298-7fd3-4870-bbb6-cfdab9da09c3" />

## How to test it
http://localhost:3000/dashboard/memberships

## Checklist
- [x] Runs locally without errors
- [x] Migrations included if models changed
- [x] No `.env` values committed
- [x] `.gitkeep` files removed from affected directories