### PR TITLE
Feature/scrum 207 208 213 general navbar

### DIFF
--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -1,6 +1,12 @@
+// React/Next.js
+import React from 'react';
+
 // Third-party
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
+
+// Components
+import { PublicNavbar } from '@/components/layout/PublicNavbar';
 
 export default async function LocaleLayout({
   children,
@@ -13,7 +19,17 @@ export default async function LocaleLayout({
 
   return (
     <NextIntlClientProvider messages={messages} locale={locale}>
-      {children}
+      <div className="flex min-h-screen flex-col">
+            {/* Navbar Section. Banner content goes above this. */}
+            <PublicNavbar />
+
+            {/* Main content area */}
+            <main className="flex-grow">
+              {children}
+            </main>
+
+            {/* <Footer /> */}
+          </div>
     </NextIntlClientProvider>
   );
 }

--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 // Third-party
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
+import { LanguageToggle } from '@/components/ui/LanguageToggle';
 
 // Components
 import { PublicNavbar } from '@/components/layout/PublicNavbar';
@@ -20,6 +21,9 @@ export default async function LocaleLayout({
   return (
     <NextIntlClientProvider messages={messages} locale={locale}>
       <div className="flex min-h-screen flex-col">
+            {/* Navbar Section. Banner content goes above this. */}
+            <LanguageToggle />
+
             {/* Navbar Section. Banner content goes above this. */}
             <PublicNavbar />
 

--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -1,6 +1,11 @@
+// Third-Party
 import React from 'react';
-import { LanguageToggle } from '@/components/ui/LanguageToggle';
 import { useTranslations } from 'next-intl';
+
+/**
+ * This is the general view home page
+ *
+ */
 
 export default function HomePage() {
   const t = useTranslations('HomePageTest');
@@ -14,11 +19,6 @@ export default function HomePage() {
           {/* Dynamically swaps 'Home' based on the current locale */}
           {t('home')} Page
         </h1>
-
-      {/* TEST: Adding the language toggle button to the right side to see if viewable */}
-        <div className="flex justify-end w-full">
-          <LanguageToggle />
-        </div>
       </header>
 
       {/* WELCOME SECTION*/}

--- a/frontend/components/layout/PublicNavbar.tsx
+++ b/frontend/components/layout/PublicNavbar.tsx
@@ -7,32 +7,44 @@ import React from 'react';
 import { useTranslations } from 'next-intl';
 
 // Project utilities/hooks
-import { Link } from '@/i18n/routing';
+import { Link, usePathname } from '@/i18n/routing';
+
+/**
+ * This exports the general view's public navbar to navigate to pages like home, events, etc.
+ *
+ */
 
 export const PublicNavbar = () => {
   const t = useTranslations('Navbar');
+  const pathname = usePathname();
 
   // Define our navigation links
   const navLinks = [
     { name: t('home'), href: '/' },
     { name: t('events'), href: '/events' },
-    { name: t('donate'), href: '/donate' },
+    { name: t('support'), href: '/support' },
     { name: t('membership'), href: '/membership' },
     { name: t('about'), href: '/about' },
     { name: t('partners'), href: '/partners' },
-    { name: t('volunteer'), href: '/volunteer' },
   ] as const;
 
   return (
     <nav className="sticky top-0 z-50 w-full border-b bg-white shadow-sm">
       <div className="container mx-auto flex h-16 items-center justify-center space-x-8 px-4">
         {navLinks.map((link) => {
+          // Check if the current path matches the link to highlight it
+          const isActive = pathname === link.href;
 
           return (
             <Link
               key={link.href}
               href={link.href}
-              className="text-sm font-medium text-gray-600 transition-colors hover:text-blue-600"
+              // Highlight code
+              className={`text-sm font-medium transition-colors hover:text-blue-600 ${
+                isActive
+                  ? 'text-blue-600 border-b-2 border-blue-600 pb-1'
+                  : 'text-gray-600'
+              }`}
             >
               {link.name}
             </Link>

--- a/frontend/components/layout/PublicNavbar.tsx
+++ b/frontend/components/layout/PublicNavbar.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+// React Next.js
+import React from 'react';
+
+// Third-Party
+import { useTranslations } from 'next-intl';
+
+// Project utilities/hooks
+import { Link } from '@/i18n/routing';
+
+export const PublicNavbar = () => {
+  const t = useTranslations('Navbar');
+
+  // Define our navigation links
+  const navLinks = [
+    { name: t('home'), href: '/' },
+    { name: t('events'), href: '/events' },
+    { name: t('donate'), href: '/donate' },
+    { name: t('membership'), href: '/membership' },
+    { name: t('about'), href: '/about' },
+    { name: t('partners'), href: '/partners' },
+    { name: t('volunteer'), href: '/volunteer' },
+  ] as const;
+
+  return (
+    <nav className="sticky top-0 z-50 w-full border-b bg-white shadow-sm">
+      <div className="container mx-auto flex h-16 items-center justify-center space-x-8 px-4">
+        {navLinks.map((link) => {
+
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-sm font-medium text-gray-600 transition-colors hover:text-blue-600"
+            >
+              {link.name}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+};

--- a/frontend/i18n/routing.ts
+++ b/frontend/i18n/routing.ts
@@ -1,0 +1,33 @@
+// Third-party libraries
+import { createNavigation } from 'next-intl/navigation';
+import { defineRouting } from 'next-intl/routing';
+
+export const routing = defineRouting({
+  // The supported languages of the website. en = English and ja = Japanese
+  locales: ['en', 'ja'],
+
+  // Set English as default to guarantee a link appears properly
+  defaultLocale: 'en',
+
+  // Define the pathnames so the website knows where to navigate to
+  pathnames: {
+    '/': '/',
+
+    // Navbar Links
+    '/about': '/about',
+    '/events': '/events',
+    '/donate': '/donate',
+    '/membership': '/membership',
+    '/partners': '/partners',
+    '/volunteer': '/volunteer',
+
+    // In case other pages are created, create the pathnames below this comment
+  },
+});
+
+/**
+ * An export to help create routings for the general view pages
+ * Contains a list ofpathnames and also keeps /en or /ja in mind when creating links
+ */
+export const { Link, redirect, usePathname, useRouter, getPathname } =
+  createNavigation(routing);

--- a/frontend/i18n/routing.ts
+++ b/frontend/i18n/routing.ts
@@ -16,10 +16,9 @@ export const routing = defineRouting({
     // Navbar Links
     '/about': '/about',
     '/events': '/events',
-    '/donate': '/donate',
+    '/support': '/support',
     '/membership': '/membership',
     '/partners': '/partners',
-    '/volunteer': '/volunteer',
 
     // In case other pages are created, create the pathnames below this comment
   },


### PR DESCRIPTION
## What does this PR do?
Adds the Navigation Bar to every general view page that currently exists.

## How to test it
The navigation bar should show up on the general view pages. Clicking on them should navigate to the other pages. Clicking the language toggle button should change the language of the navigation bar text.

<img width="1892" height="505" alt="image" src="https://github.com/user-attachments/assets/ba2efcee-315e-4cfd-b793-ac2f1a66b024" />

<img width="1881" height="488" alt="image" src="https://github.com/user-attachments/assets/be723392-0c35-4d4c-aa12-19dc369fd4bd" />

<img width="1915" height="236" alt="image" src="https://github.com/user-attachments/assets/9db9d69a-ea10-4e4b-bf7b-e286f671a11f" />


## Checklist
- [x] Runs locally without errors
- [x] Migrations included if models changed
- [x] No `.env` values committed
- [x] `.gitkeep` files removed from affected directories