### PR TITLE
style(SCRUM-34): added teal color to public navbar background

### DIFF
--- a/frontend/components/layout/PublicNavbar.tsx
+++ b/frontend/components/layout/PublicNavbar.tsx
@@ -29,7 +29,7 @@ export const PublicNavbar = () => {
   ] as const;
 
   return (
-    <nav className="sticky top-0 z-50 w-full border-b bg-white shadow-sm">
+    <nav className="sticky top-0 z-50 w-full border-b bg-teal-900 shadow-sm">
       <div className="container mx-auto flex h-16 items-center justify-center space-x-8 px-4">
         {navLinks.map((link) => {
           // Check if the current path matches the link to highlight it
@@ -40,10 +40,10 @@ export const PublicNavbar = () => {
               key={link.href}
               href={link.href}
               // Highlight code
-              className={`text-sm font-medium transition-colors hover:text-blue-600 ${
+              className={`text-sm font-medium transition-colors ${
                 isActive
-                  ? 'text-blue-600 border-b-2 border-blue-600 pb-1'
-                  : 'text-gray-600'
+                  ? '!text-white border-b-2 border-white pb-1'
+                  : '!text-white/70 hover:text-white'
               }`}
             >
               {link.name}


### PR DESCRIPTION
## What does this PR do?
Turns the public navbar background color to teal

## How to test it
The navbar should look like this:
<img width="1894" height="320" alt="image" src="https://github.com/user-attachments/assets/8bbf3c9e-c946-4b30-9f2a-40588835d4ae" />

Testable at http://localhost:3000/en

## Checklist
- [x] Runs locally without errors
- [x] Migrations included if models changed
- [x] No `.env` values committed
- [x] `.gitkeep` files removed from affected directories