### PR TITLE
feat(SCRUM-292-293-294): add textbox generator buttons and textbox ed…

### DIFF
--- a/frontend/app/admin/editpages/page.tsx
+++ b/frontend/app/admin/editpages/page.tsx
@@ -1,7 +1,96 @@
-import React from 'react';
+'use client';
 
-export default function editPagesPage() {
+// React
+import React, { useState } from 'react';
+
+// uuid
+import { v4 as uuidv4 } from 'uuid';
+
+// Types
+import { ContentBlock, BlockType } from '@/types/content';
+
+// Components
+import BilingualInput from '@/components/admin/BilingualInput';
+
+/**
+ * Admin page for allowing client to dynamically add/edit content on their website
+ * Content is managed as a list of ContentBlocks
+ */
+
+export default function EditPagesPage() {
+  // Block array
+  const [blocks, setBlocks] = useState<ContentBlock[]>([]);
+
+  // ContentBlock creation
+  const addBlock = (type: BlockType) =>{
+    const newBlock: ContentBlock = {
+      id: uuidv4(),
+      type: type,
+      contentEn: '',
+      contentJa: '',
+    };
+    setBlocks([...blocks, newBlock]);
+  };
+
+  // Updating blocks
+  const updateBlock = (updatedBlock: ContentBlock) => {
+        setBlocks(blocks.map((b) => (b.id === updatedBlock.id ? updatedBlock : b)));
+    };
+
   return (
-    <h1>Edit Pages Page</h1>
+    <div className="p-10 max-w-content mx-auto font-body bg-msscc-white min-h-screen text-msscc-gray-dark">
+        <h1 className="font-heading text-display mb-10 text-msscc-teal border-b border-msscc-gray-light pb-4">
+            Edit Pages Page
+        </h1>
+
+        <div className="flex flex-col md:flex-row gap-10">
+            {/* The 3 Buttons used to generate the textbox containers */}
+            <div className="md:w-48 flex flex-col space-y-3">
+                <h2 className="text-eyebrow tracking-eyebrow uppercase text-msscc-gray-mid">
+                    Add Content
+                </h2>
+                <button
+                    onClick={() => addBlock('header')}
+                    className="bg-msscc-pink hover:bg-msscc-pink-dark text-white text-btn tracking-btn px-4 py-2 rounded-sm transition-colors text-left"
+                >
+                    + Header
+                </button>
+                <button
+                    onClick={() => addBlock('paragraph')}
+                    className="bg-msscc-pink hover:bg-msscc-pink-dark text-white text-btn tracking-btn px-4 py-2 rounded-sm transition-colors text-left"
+                >
+                    + Paragraph
+                </button>
+                <button
+                    onClick={() => addBlock('caption')}
+                    className="bg-msscc-pink hover:bg-msscc-pink-dark text-white text-btn tracking-btn px-4 py-2 rounded-sm transition-colors text-left"
+                >
+                    + Caption
+                </button>
+            </div>
+
+            {/* Loop through blocks array to show each created block */}
+            <div className="flex-1 space-y-6">
+                {blocks.map((block) => (
+                    <BilingualInput
+                        key={block.id}
+                        title={block.type}
+                        labelEn="English Text"
+                        labelJa="Japanese Text"
+                        valueEn={block.contentEn}
+                        valueJa={block.contentJa}
+                        onUpdateEn={(val) => updateBlock({ ...block, contentEn: val })}
+                        onUpdateJa={(val) => updateBlock({ ...block, contentJa: val })}
+                    />
+                ))}
+
+                {blocks.length === 0 && (
+                    <div className="text-center text-msscc-gray-mid py-20 border border-dashed border-msscc-gray-light rounded-lg font-body">
+                        No blocks added yet. Use the sidebar buttons to start building your page.
+                    </div>
+                )}
+            </div>
+        </div>
+    </div>
   );
 }

--- a/frontend/components/admin/BilingualInput.tsx
+++ b/frontend/components/admin/BilingualInput.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+// React
+import React from 'react';
+
+interface BilingualInputProps {
+    labelEn: string;
+    labelJa: string;
+    valueEn: string;
+    valueJa: string;
+    onUpdateEn: (val: string) => void;
+    onUpdateJa: (val: string) => void;
+    title?: string; // Optional title like "Header" or "Board Member Name"
+}
+
+/**
+ * Reusable textbox components for side-by-side English and Japanese text entry.
+ */
+export default function BilingualInput({
+    labelEn,
+    labelJa,
+    valueEn,
+    valueJa,
+    onUpdateEn,
+    onUpdateJa,
+    title
+}: BilingualInputProps) {
+    return (
+      <div className="relative border border-msscc-gray-light p-6 rounded-md bg-white shadow-none">
+          {title && (
+              <div className="flex justify-between items-center mb-6">
+                  <span className="text-eyebrow tracking-eyebrow uppercase text-msscc-pink font-bold">
+                      {title}
+                  </span>
+              </div>
+          )}
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {/* English Textbox */}
+              <div>
+                  <label className="block text-label tracking-label text-msscc-gray-mid uppercase mb-2">
+                      {labelEn}
+                  </label>
+                  <textarea
+                      className="w-full p-4 border border-msscc-gray-light rounded-md font-body text-body focus:ring-focus-admin outline-none"
+                      rows={4}
+                      value={valueEn}
+                      onChange={(e) => onUpdateEn(e.target.value)}
+                  />
+              </div>
+
+              {/* Japanese Textbox */}
+              <div>
+                  <label className="block text-label tracking-label text-msscc-gray-mid uppercase mb-2">
+                      {labelJa}
+                  </label>
+                  <textarea
+                      className="w-full p-4 border border-msscc-gray-light rounded-md font-jp text-body bg-white focus:ring-focus-admin outline-none"
+                      rows={4}
+                      value={valueJa}
+                      onChange={(e) => onUpdateJa(e.target.value)}
+                  />
+              </div>
+          </div>
+      </div>
+    );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.71.2",
+        "uuid": "^13.0.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -6477,6 +6478,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.71.2",
+    "uuid": "^13.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/frontend/types/content.ts
+++ b/frontend/types/content.ts
@@ -1,0 +1,14 @@
+/**
+ * Defines the type of text blocks created in the Page Edit page
+ */
+export type BlockType = 'header' | 'paragraph' | 'caption';
+
+/**
+ * Defines the data structure of a text block created in the Page Edit page
+ */
+export interface ContentBlock{
+  id: string;
+  type: BlockType;
+  contentEn: string;
+  contentJa: string;
+}


### PR DESCRIPTION
…itors

## What does this PR do?
Modifies the admin Page Edit page to include buttons that generates text editor boxes.

## How to test it
cd frontend && npm install
^ This is for the uuid related features.

On the Page Edit page, it should initially look like this:
<img width="1886" height="891" alt="image" src="https://github.com/user-attachments/assets/24e1d379-2c3a-48e2-af42-4032b5e58b22" />

Clicking one of the buttons should make textboxes show like this:
<img width="1896" height="895" alt="image" src="https://github.com/user-attachments/assets/70622bca-9d2f-4d9b-bb7c-61273553c886" />

Testing is done at http://localhost:3000/admin/editpages

## Checklist
- [x] Runs locally without errors
- [x] Migrations included if models changed
- [x] No `.env` values committed
- [x] `.gitkeep` files removed from affected directories