### PR TITLE
Feature/scrum 135 deepl translate button

### DIFF
--- a/frontend/app/admin/editpages/page.tsx
+++ b/frontend/app/admin/editpages/page.tsx
@@ -37,6 +37,31 @@ export default function EditPagesPage() {
         setBlocks(blocks.map((b) => (b.id === updatedBlock.id ? updatedBlock : b)));
     };
 
+  // Deepl translate button handling
+  const handleTranslate = async (id: string, textToTranslate: string) => {
+    try {
+        // Send the text to be converted as a package
+        const response = await fetch('/api/translate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text: textToTranslate }),
+        });
+
+        const data = await response.json();
+
+        // Ensure that the newly translated text is placed in the correct content block
+        if (data.translation) {
+            setBlocks((prevBlocks) => // Search the array in its current state
+                prevBlocks.map((block) =>
+                    block.id === id ? { ...block, contentJa: data.translation } : block // Search based on block id
+                )
+            );
+        }
+    } catch (error) {
+        console.error("Translation failed:", error);
+    }
+};
+
   return (
     <div className="p-10 max-w-content mx-auto font-body bg-msscc-white min-h-screen text-msscc-gray-dark">
         <h1 className="font-heading text-display mb-10 text-msscc-teal border-b border-msscc-gray-light pb-4">
@@ -81,6 +106,7 @@ export default function EditPagesPage() {
                         valueJa={block.contentJa}
                         onUpdateEn={(val) => updateBlock({ ...block, contentEn: val })}
                         onUpdateJa={(val) => updateBlock({ ...block, contentJa: val })}
+                        onTranslate={() => handleTranslate(block.id, block.contentEn)}
                     />
                 ))}
 

--- a/frontend/app/api/translate/route.ts
+++ b/frontend/app/api/translate/route.ts
@@ -1,0 +1,42 @@
+// Next
+import { NextResponse } from 'next/server';
+
+/**
+ * Deepl API Implementation
+ * Sends our desired text to the Deepl servers to be translated to Japanese
+ */
+export async function POST(req: Request){
+  try{
+    const { text, targetLang = 'JA'} = await req.json();
+    const apiKey = process.env.DEEPL_API_KEY;
+
+    if (!text){
+      return NextResponse.json({ error: 'No text provided'}, { status: 400 });
+    }
+
+    // Ping DeepL API
+    const response = await fetch ('https://api-free.deepl.com/v2/translate', {
+      method: 'POST',
+      headers: {
+        'Authorization': `DeepL-Auth-Key ${apiKey}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      // Send the text we want translated and the target language we want it in (Japanese)
+      body: new URLSearchParams({
+        text,
+        target_lang: targetLang,
+      }),
+    });
+
+    const data = await response.json();
+
+    // Return translated text
+    return NextResponse.json({
+      translation: data.translations[0].text
+    });
+
+  } catch (error){
+    console.error('Translation Error', error);
+    return NextResponse.json({ error: 'Failed to translate' }, {status: 500 });
+  }
+}

--- a/frontend/components/admin/BilingualInput.tsx
+++ b/frontend/components/admin/BilingualInput.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 // React
-import React from 'react';
+import React, { useState } from 'react';
 
 interface BilingualInputProps {
     labelEn: string;
@@ -11,6 +11,7 @@ interface BilingualInputProps {
     onUpdateEn: (val: string) => void;
     onUpdateJa: (val: string) => void;
     title?: string; // Optional title like "Header" or "Board Member Name"
+    onTranslate: () => Promise<void>; // For deepl button
 }
 
 /**
@@ -23,8 +24,21 @@ export default function BilingualInput({
     valueJa,
     onUpdateEn,
     onUpdateJa,
-    title
+    title,
+    onTranslate,
 }: BilingualInputProps) {
+    // State to show that the translation is processing
+    const [isTranslating, setIsTranslating] = useState(false);
+
+    const handleTranslationClick = async () => {
+        setIsTranslating(true);
+        try {
+            await onTranslate();
+        } finally {
+            setIsTranslating(false);
+        }
+    };
+
     return (
       <div className="relative border border-msscc-gray-light p-6 rounded-md bg-white shadow-none">
           {title && (
@@ -38,9 +52,11 @@ export default function BilingualInput({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {/* English Textbox */}
               <div>
-                  <label className="block text-label tracking-label text-msscc-gray-mid uppercase mb-2">
-                      {labelEn}
-                  </label>
+                  <div className="flex items-end mb-2 h-9">
+                    <label className="block text-label tracking-label text-msscc-gray-mid uppercase mb-2">
+                        {labelEn}
+                    </label>
+                  </div>
                   <textarea
                       className="w-full p-4 border border-msscc-gray-light rounded-md font-body text-body focus:ring-focus-admin outline-none"
                       rows={4}
@@ -51,9 +67,25 @@ export default function BilingualInput({
 
               {/* Japanese Textbox */}
               <div>
-                  <label className="block text-label tracking-label text-msscc-gray-mid uppercase mb-2">
+                  {/* Translate Button */}
+                  <div className="flex justify-between items-end mb-2 h-9">
+                  <label className="block text-label tracking-label text-msscc-gray-mid uppercase">
                       {labelJa}
                   </label>
+
+                  <button
+                          onClick={handleTranslationClick}
+                          disabled={isTranslating || !valueEn}
+                          className={`text-[10px] uppercase font-bold tracking-widest px-3 py-1.5 rounded border transition-all
+                            ${isTranslating
+                                ? 'bg-gray-100 text-msscc-gray-mid border-msscc-gray-light'
+                                : 'bg-msscc-teal/10 text-msscc-teal border-msscc-teal/30 hover:bg-msscc-teal hover:text-white active:transform active:scale-95'}
+                            disabled:opacity-50 disabled:cursor-not-allowed`}
+                      >
+                          {isTranslating ? 'Translating...' : 'Translate to Japanese'}
+                      </button>
+                  </div>
+
                   <textarea
                       className="w-full p-4 border border-msscc-gray-light rounded-md font-jp text-body bg-white focus:ring-focus-admin outline-none"
                       rows={4}


### PR DESCRIPTION
## Dependent on this PR being completed first:
https://github.com/Ulisses37/msscc/pull/45

## What does this PR do?
Adds the Deepl API translate button to the textbox editors to convert English text to Japanese.

## How to test it
First, please update the .env.local file inside the frontend folder. I uploaded the .env.local file in our shared drive for you to copy.
After updating the .env.local file, you will need to restart the frontend server for changes to take effect.

The Page Edit page should now be updated to show the translate button. Typing text in the English textbox and then clicking the translate button should automatically translate the text to Japanese. (Please translate a really short sentence once as we only have a 500,000 max character limit per month).
<img width="1879" height="873" alt="image" src="https://github.com/user-attachments/assets/cb0722a9-b742-47d0-9646-43121c094e2b" />

Testing is done at http://localhost:3000/admin/editpages

## Checklist
- [x] Runs locally without errors
- [x] Migrations included if models changed
- [x] No `.env` values committed
- [x] `.gitkeep` files removed from affected directories