### PR TITLE
[SCRUM-299] Add delete button

### DIFF
--- a/frontend/app/admin/editpages/page.tsx
+++ b/frontend/app/admin/editpages/page.tsx
@@ -32,6 +32,16 @@ export default function EditPagesPage() {
     setBlocks([...blocks, newBlock]);
   };
 
+  // Removing ContentBlock from array.
+  const handleDeleteBlock = (id: string) => {
+    const isConfirmed = window.confirm("Are you sure you want to remove this block? This cannot be undone.");
+    
+    // Use filter() to create a new array without the block chosen for deletion
+    if (isConfirmed) {
+      setBlocks((prevBlocks) => prevBlocks.filter((block) => block.id !== id));
+    }
+  };
+
   // Updating blocks
   const updateBlock = (updatedBlock: ContentBlock) => {
         setBlocks(blocks.map((b) => (b.id === updatedBlock.id ? updatedBlock : b)));
@@ -107,6 +117,7 @@ export default function EditPagesPage() {
                         onUpdateEn={(val) => updateBlock({ ...block, contentEn: val })}
                         onUpdateJa={(val) => updateBlock({ ...block, contentJa: val })}
                         onTranslate={() => handleTranslate(block.id, block.contentEn)}
+                        onDelete={() => handleDeleteBlock(block.id)}
                     />
                 ))}
 

--- a/frontend/components/admin/BilingualInput.tsx
+++ b/frontend/components/admin/BilingualInput.tsx
@@ -12,6 +12,7 @@ interface BilingualInputProps {
     onUpdateJa: (val: string) => void;
     title?: string; // Optional title like "Header" or "Board Member Name"
     onTranslate: () => Promise<void>; // For deepl button
+    onDelete: () => void; // For delete button
 }
 
 /**
@@ -26,6 +27,7 @@ export default function BilingualInput({
     onUpdateJa,
     title,
     onTranslate,
+    onDelete,
 }: BilingualInputProps) {
     // State to show that the translation is processing
     const [isTranslating, setIsTranslating] = useState(false);
@@ -40,7 +42,20 @@ export default function BilingualInput({
     };
 
     return (
-      <div className="relative border border-msscc-gray-light p-6 rounded-md bg-white shadow-none">
+      <div className="group relative border border-msscc-gray-light p-6 rounded-md bg-white shadow-none">
+
+        {/* DELETE BUTTON */}
+        <button
+            onClick={onDelete}
+            className="absolute top-3 right-3 p-1.5 text-msscc-gray-mid hover:text-msscc-pink hover:bg-msscc-pink/10 rounded-full transition-all opacity-0 group-hover:opacity-100"
+            title="Remove Block"
+            type="button"
+        >
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2.5">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+        </button>
+
           {title && (
               <div className="flex justify-between items-center mb-6">
                   <span className="text-eyebrow tracking-eyebrow uppercase text-msscc-pink font-bold">


### PR DESCRIPTION
## What does this PR do?
Adds a delete button to the text containers created in the Page Edit page.

## How to test it
In the Page Edit page, click on any one of the buttons under Add Content. 
A text container should appear. Move your mouse over the container and an X button should appear in the top right corner of the container.
Click on the button and it will ask you to confirm the deletion. After confirming, the container should disappear from the screen.
<img width="1891" height="821" alt="image" src="https://github.com/user-attachments/assets/070c5236-dc39-4ab7-9d41-2d7942a9823f" />

Tested at http://localhost:3000/admin/editpages

## Checklist
- [x] Runs locally without errors
- [x] Migrations included if models changed
- [x] No `.env` values committed
- [x] `.gitkeep` files removed from affected directories