### PR TITLE
security: rotate Django secret key and move to environment variables

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,30 @@
-SECRET_KEY=your-secret-key-here
-DEBUG=True
-DATABASE_URL=postgresql://user:password@host:port/dbname
-ALLOWED_HOSTS=localhost,127.0.0.1
+# === Django ===
+DJANGO_SECRET_KEY=
+DJANGO_DEBUG=True
+DJANGO_SETTINGS_MODULE=config.settings.development
+
+# Server Configuration (only needed for remote dev environments)
+# Uncomment and set to your server's IP if using JetBrains Gateway or similar
+# DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,<your-server-tailscale-ip>
+
+# CORS Configuration
 CORS_ALLOWED_ORIGINS=http://localhost:3000
-DEEPL_API_KEY=your-deepl-key-here
+# For remote dev, add your server IP:
+# CORS_ALLOWED_ORIGINS=http://localhost:3000,http://<your-server-tailscale-ip>:3000
+
+# === PostgreSQL ===
+DB_NAME=
+DB_USER=
+DB_PASSWORD=
+DB_HOST=
+DB_PORT=
+
+# === MinIO / S3 Storage ===
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+S3_BUCKET=
+S3_ENDPOINT_URL=
+S3_REGION=auto
+
+# === DeepL API ===
+DEEPL_API_KEY=

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -24,7 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-9$=h0t(a^58h1xn9ay@-6^e+9^k01t(x4-*$9dm#9yne5fuxhs'
+SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -81,7 +81,9 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'config.wsgi.application'
 
-CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOWED_ORIGINS = os.environ.get('CORS_ALLOWED_ORIGINS',
+                                      'http://localhost:3000').split(',')
+
 CORS_ALLOW_METHODS = [
     "GET",
     "POST",

--- a/backend/config/settings/development.py
+++ b/backend/config/settings/development.py
@@ -1,13 +1,7 @@
 from .base import *
-import os
 
-DEBUG = True
-ALLOWED_HOSTS = ['localhost', '127.0.0.1']
-
-import os
-
-from .base import *
-
+DEBUG = os.environ.get('DJANGO_DEBUG', 'True').lower() in ('true', '1', 'yes')
+ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',')
 
 DATABASES = {
     "default": {


### PR DESCRIPTION
## What does this PR do?

Rotates the Django secret key (which was accidentally exposed in Git history) and migrates all environment-specific configuration to environment variables for better security and flexibility.

**Security improvements:**
- Removes hardcoded `SECRET_KEY` from `base.py`
- Replaces `CORS_ALLOW_ALL_ORIGINS = True` with explicit allowlist
- Moves sensitive config to `.env` files

**Configuration improvements:**
- Updated `.env.example` template with all required variables
- Supports remote development environments (JetBrains Gateway, etc.)
- Makes `ALLOWED_HOSTS`, `CORS_ALLOWED_ORIGINS`, and `DEBUG` configurable via env vars

## How to test it

** BREAKING CHANGE **
This made changes to env properties and variables. I recommend updating backend/.env to new template from .env.example and populating it from shared env file.

To Test: 
 - Run the backend server
```bash
   cd backend
   python3 manage.py runserver
```
 - It should start without errors. Visit `http://localhost:8000/admin/` to verify. Django login panel should appear.
- Run the frontend server
```bash
   cd frontend
   npm run dev
```
- It should start up without errors. Visit any page, such as `http://localhost:3000/en/partners`. Check browser console (F12) for any unusual errors.

## Checklist
- [ ] Runs locally without errors
- [ ] Migrations included if models changed
- [ ] No `.env` values committed
- [ ] `.gitkeep` files removed from affected directories