### PR TITLE
[Scrum-72-139] Image Replacement for Boardmembers-Events-Partners

### DIFF
--- a/backend/board_members/urls.py
+++ b/backend/board_members/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from board_members.views import BoardMemberListView
+from board_members.views import BoardMemberListView, BoardMemberDetailView
 
 urlpatterns = [
     path("", BoardMemberListView.as_view(), name="board-member-list"),
+    path("<int:board_member_id>/", BoardMemberDetailView.as_view(), name="board-member-detail"),
 ]

--- a/backend/board_members/views.py
+++ b/backend/board_members/views.py
@@ -9,3 +9,11 @@ class BoardMemberListView(generics.ListAPIView):
 
     queryset = BoardMember.objects.all().order_by("display_order", "board_member_id")
     serializer_class = BoardMemberSerializer
+
+
+class BoardMemberDetailView(generics.RetrieveUpdateAPIView):
+    """Retrieve or update a single board member."""
+
+    queryset = BoardMember.objects.all()
+    serializer_class = BoardMemberSerializer
+    lookup_field = "board_member_id"

--- a/backend/events/urls.py
+++ b/backend/events/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from events.views import EventListView
+from events.views import EventListView, EventDetailView
 
 urlpatterns = [
     path("", EventListView.as_view(), name="event-list"),
+    path("<int:event_id>/", EventDetailView.as_view(), name="event-detail"),
 ]

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -9,3 +9,11 @@ class EventListView(generics.ListAPIView):
 
     queryset = Event.objects.all().order_by("start_datetime", "event_id")
     serializer_class = EventSerializer
+
+
+class EventDetailView(generics.RetrieveUpdateAPIView):
+    """Retrieve or update a single event."""
+
+    queryset = Event.objects.all()
+    serializer_class = EventSerializer
+    lookup_field = "event_id"

--- a/backend/partners/urls.py
+++ b/backend/partners/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from partners.views import PartnerListView
+from partners.views import PartnerListView, PartnerDetailView
 
 urlpatterns = [
     path("", PartnerListView.as_view(), name="partner-list"),
+    path("<int:partner_id>/", PartnerDetailView.as_view(), name="partner-detail"),
 ]

--- a/backend/partners/views.py
+++ b/backend/partners/views.py
@@ -9,3 +9,11 @@ class PartnerListView(generics.ListAPIView):
 
     queryset = Partner.objects.all().order_by("display_order", "partner_id")
     serializer_class = PartnerSerializer
+
+
+class PartnerDetailView(generics.RetrieveUpdateAPIView):
+    """Retrieve or update a single partner."""
+
+    queryset = Partner.objects.all()
+    serializer_class = PartnerSerializer
+    lookup_field = "partner_id"

--- a/frontend/app/admin/dashboard/page.tsx
+++ b/frontend/app/admin/dashboard/page.tsx
@@ -125,10 +125,6 @@ export default function Dashboard() {
       )}
 
       <section className="w-full max-w-2xl bg-white border border-slate-200 rounded-xl shadow-sm p-6">
-        <h2 className="text-xl font-medium mb-4">Additional Admin Tools</h2>
-        <p className="text-sm text-slate-600">
-          Placeholder for future administrative functionalities.
-        </p>
         <ReplaceImage />
       </section>
     </main>

--- a/frontend/app/admin/dashboard/page.tsx
+++ b/frontend/app/admin/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { ImportImage } from "@/components/ui/ImportImage";
 import { ImageDeletionManager } from "@/components/ui/ImageDeletionManager";
+import ReplaceImage from "@/components/admin/ReplaceImage";
 
 
 export default function Dashboard() {
@@ -122,6 +123,14 @@ export default function Dashboard() {
       {showDeleteManager && (
         <ImageDeletionManager onClose={() => setShowDeleteManager(false)} />
       )}
+
+      <section className="w-full max-w-2xl bg-white border border-slate-200 rounded-xl shadow-sm p-6">
+        <h2 className="text-xl font-medium mb-4">Additional Admin Tools</h2>
+        <p className="text-sm text-slate-600">
+          Placeholder for future administrative functionalities.
+        </p>
+        <ReplaceImage />
+      </section>
     </main>
   );
 }

--- a/frontend/components/admin/ReplaceImage.tsx
+++ b/frontend/components/admin/ReplaceImage.tsx
@@ -23,6 +23,7 @@ export default function ReplaceImage() {
   const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
   const [selectedMediaAssetId, setSelectedMediaAssetId] = useState<number | null>(null);
   const [selectedReplacementId, setSelectedReplacementId] = useState<number | null>(null);
+  const [selectedModelId, setSelectedModelId] = useState<number | null>(null);
 
   {/** Expect an image for transfer to storage */}
   const uploadImage = async (file: File) => {
@@ -47,23 +48,47 @@ export default function ReplaceImage() {
 
   {/* Response to an image being submitted */}
   const handleSubmit = async () => {
-    if (!selectedFile) {
+    if (!selectedFile && !selectedReplacementId) {
       setSubmitError('Please select an image before submitting.');
       return;
     }
-
+    let replacementId = selectedReplacementId;
     setIsSubmitting(true);
     setSubmitError(null);
     setUploadedUrl(null);
+    if (selectedFile && imageMode === "upload") {
+      try {
+        const data = await uploadImage(selectedFile);
+        setUploadedUrl(data.url);
+        replacementId = data.media_asset_id;
+        setSelectedReplacementId(replacementId); // Use the new media_asset_id for replacement
+      } catch (error) {
+        setSubmitError(error instanceof Error ? error.message : 'Upload failed.');
+      }
+    }
 
     try {
-      const data = await uploadImage(selectedFile);
-      setUploadedUrl(data.url);
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/api/${selectedModel}/${selectedModelId}/`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ media_asset: selectedReplacementId }),
+        }
+      );
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => null);
+        throw new Error(errorData?.error || 'Failed to update record.');
+      }
+      setSubmitError(null);
     } catch (error) {
-      setSubmitError(error instanceof Error ? error.message : 'Upload failed.');
+      setSubmitError(error instanceof Error ? error.message : 'Failed to update record.');
     } finally {
       setIsSubmitting(false);
     }
+
   };
 
 
@@ -72,7 +97,7 @@ export default function ReplaceImage() {
       <h3 className="text-1xl mb-6">Replace Image</h3>
 
       <div className="flex flex-col items-center gap-6">
-        Select where you would like to replace an image:
+        Select what image you would like to replace:
         <div className="flex gap-4">
           {(selectedModel === "events" || selectedModel === null) && (
             <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
@@ -96,7 +121,10 @@ export default function ReplaceImage() {
 
         <RetrieveImageList
           modelType={selectedModel}
-          onSelect={(mediaAssetId) => setSelectedMediaAssetId(mediaAssetId)}
+          onSelect={(mediaAssetId, modelId) => {
+            setSelectedMediaAssetId(mediaAssetId);
+            setSelectedModelId(modelId);
+          }}
           selectedId={selectedMediaAssetId}
         />
         <div className="text-sm text-slate-600">
@@ -150,18 +178,25 @@ export default function ReplaceImage() {
               />
            </div>
         )}
-        {selectedReplacementId !== null && (
+        {imageMode !== null && (
           <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={handleSubmit}
-              disabled={!selectedFile || isSubmitting}
+              disabled={
+                isSubmitting ||
+                (imageMode === "upload" && !selectedFile) ||
+                (imageMode === "select" && !selectedReplacementId)
+              }
               className="rounded-md bg-slate-900 text-white px-4 py-2 text-sm font-medium disabled:bg-slate-400"
             >
               {isSubmitting ? 'Submitting…' : 'Submit Image'}
             </button>
             <span className="text-sm text-slate-700">
               {selectedFile ? selectedFile.name : 'No file selected.'}
+              {selectedReplacementId && imageMode === "select" && (
+                <span className="ml-2">Selected: {selectedReplacementId}</span>
+              )}
             </span>
           </div>
         )}

--- a/frontend/components/admin/ReplaceImage.tsx
+++ b/frontend/components/admin/ReplaceImage.tsx
@@ -125,6 +125,7 @@ export default function ReplaceImage() {
             setSelectedModelId(modelId);
           }}
           selectedId={selectedMediaAssetId}
+          selectedModelId={selectedModelId}
         />
 
         <div className="text-sm text-slate-600">

--- a/frontend/components/admin/ReplaceImage.tsx
+++ b/frontend/components/admin/ReplaceImage.tsx
@@ -13,7 +13,7 @@ import PostImage from "@/components/ui/PostImage";
 import { RetrieveImageList } from "@/components/ui/RetrieveImageList";
 import Image from "next/image";
 
-type ModelType = "media" | "events" | "board-members" | "partners";
+type ModelType = "events" | "board-members" | "partners";
 
 export default function ReplaceImage() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -73,12 +73,6 @@ export default function ReplaceImage() {
       <div className="flex flex-col items-center gap-6">
         Select where you would like to replace an image:
         <div className="flex gap-4">
-          {(selectedModel === "media" || selectedModel === null) && (
-            <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-            onClick={() => setSelectedModel(prev =>prev === "media" ? null : "media")}>
-              {selectedModel === null ? "Media" : "Cancel"}
-            </button>
-          )}
           {(selectedModel === "events" || selectedModel === null) && (
             <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
             onClick={() => setSelectedModel(prev =>prev === "events" ? null : "events")}>

--- a/frontend/components/admin/ReplaceImage.tsx
+++ b/frontend/components/admin/ReplaceImage.tsx
@@ -62,8 +62,11 @@ export default function ReplaceImage() {
         setUploadedUrl(data.url);
         replacementId = data.media_asset_id;
         setSelectedReplacementId(replacementId); // Use the new media_asset_id for replacement
+        console.log("UPLOAD RESPONSE:", data);
       } catch (error) {
         setSubmitError(error instanceof Error ? error.message : 'Upload failed.');
+        setIsSubmitting(false);
+        return;
       }
     }
 
@@ -75,7 +78,7 @@ export default function ReplaceImage() {
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ media_asset: selectedReplacementId }),
+          body: JSON.stringify({ media_asset: replacementId }),
         }
       );
       if (!response.ok) {

--- a/frontend/components/admin/ReplaceImage.tsx
+++ b/frontend/components/admin/ReplaceImage.tsx
@@ -9,19 +9,20 @@
 
 import React, { useState, useEffect } from "react";
 import { ImportImage } from "@/components/ui/ImportImage";
-import PostImage from "@/components/ui/PostImage";
 import { RetrieveImageList } from "@/components/ui/RetrieveImageList";
 import Image from "next/image";
 
-type ModelType = "events" | "board-members" | "partners";
+type ModelType = "media" | "events" | "board-members" | "partners";
 
 export default function ReplaceImage() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [selectedModel, setSelectedModel] = useState<ModelType | null>(null);
+  const [imageMode, setImageMode] = useState<"upload" | "select" | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
   const [selectedMediaAssetId, setSelectedMediaAssetId] = useState<number | null>(null);
+  const [selectedReplacementId, setSelectedReplacementId] = useState<number | null>(null);
 
   {/** Expect an image for transfer to storage */}
   const uploadImage = async (file: File) => {
@@ -92,39 +93,52 @@ export default function ReplaceImage() {
             </button>
           )}
         </div>
+
+        <RetrieveImageList
+          modelType={selectedModel}
+          onSelect={(mediaAssetId) => setSelectedMediaAssetId(mediaAssetId)}
+          selectedId={selectedMediaAssetId}
+        />
         <div className="text-sm text-slate-600">
           {selectedModel ? `Pick an image` : "No category selected."}
-          <RetrieveImageList modelType={selectedModel} onSelect={(mediaAssetId) => setSelectedMediaAssetId(mediaAssetId)} />
+          <div className="grid grid-cols-2 divide-x divide-slate-300 border rounded-md overflow-hidden text-sm text-slate-600">
+            <button
+              onClick={() =>
+                setImageMode(prev => prev === "upload" ? null : "upload")
+              }
+              className={`flex items-center justify-center p-3 transition ${
+                imageMode === "upload" ? "bg-blue-50 text-blue-700" : "hover:bg-slate-50"
+              }`}
+            >
+              Import New Image
+            </button>
+            <button
+              onClick={() =>
+                setImageMode(prev => prev === "select" ? null : "select")
+              }
+              className={`flex items-center justify-center p-3 transition ${
+                imageMode === "select" ? "bg-blue-50 text-blue-700" : "hover:bg-slate-50"
+              }`}
+            >
+              Select Existing Image
+            </button>
+          </div>
         </div>
-        {/* Image upload component */}
-        <ImportImage
-             onChange={(file) => setSelectedFile(file)}
-             label="Upload a replacement image"
-        />
-
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={handleSubmit}
-            disabled={!selectedFile || isSubmitting}
-            className="rounded-md bg-slate-900 text-white px-4 py-2 text-sm font-medium disabled:bg-slate-400"
-          >
-            {isSubmitting ? 'Submitting…' : 'Submit Image'}
-          </button>
-          <span className="text-sm text-slate-700">
-            {selectedFile ? selectedFile.name : 'No file selected.'}
-          </span>
-        </div>
-
-        {submitError && <p className="text-sm text-red-600">{submitError}</p>}
-        {uploadedUrl && (
-          <p className="text-sm text-green-700">
-            Image uploaded successfully: <span className="underline">{uploadedUrl}</span>
-          </p>
+        {imageMode === "upload" && (
+          <ImportImage
+            onChange={(file) => setSelectedFile(file)}
+            label="Upload a replacement image"
+          />
         )}
-
+        {imageMode === "select" && (
+          <RetrieveImageList
+            modelType={"media"}
+            onSelect={(mediaAssetId) => setSelectedReplacementId(mediaAssetId)}
+            selectedId={selectedReplacementId}
+          />
+        )}
         {/* Display selected image for reference */}
-        {selectedFile && (
+        {selectedFile && imageMode === "upload" && (
            <div className="mt-6">
              <h4 className="text-lg font-medium mb-2">Selected Image:</h4>
              <Image
@@ -136,7 +150,28 @@ export default function ReplaceImage() {
               />
            </div>
         )}
+        {selectedReplacementId !== null && (
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!selectedFile || isSubmitting}
+              className="rounded-md bg-slate-900 text-white px-4 py-2 text-sm font-medium disabled:bg-slate-400"
+            >
+              {isSubmitting ? 'Submitting…' : 'Submit Image'}
+            </button>
+            <span className="text-sm text-slate-700">
+              {selectedFile ? selectedFile.name : 'No file selected.'}
+            </span>
+          </div>
+        )}
 
+        {submitError && <p className="text-sm text-red-600">{submitError}</p>}
+        {uploadedUrl && (
+          <p className="text-sm text-green-700">
+            Image uploaded successfully: <span className="underline">{uploadedUrl}</span>
+          </p>
+        )}
       </div>
 
     </main>

--- a/frontend/components/admin/ReplaceImage.tsx
+++ b/frontend/components/admin/ReplaceImage.tsx
@@ -1,13 +1,6 @@
-//query Selected model >> Get {ID, media_asset_id, file_url, file_name}
-//Display file_url as image, for reference
-//insert new selected media_asset_id into Selected model
-//or import new image, which creates new media_asset_id, then insert that ID into Selected model
-//save Selected model to database
-//Display success message to user
-
 'use client';
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { ImportImage } from "@/components/ui/ImportImage";
 import { RetrieveImageList } from "@/components/ui/RetrieveImageList";
 import Image from "next/image";
@@ -46,23 +39,25 @@ export default function ReplaceImage() {
     return response.json();
   };
 
-  {/* Response to an image being submitted */}
+  {/* Expect mediaId and modelId for changing old mediaIds*/}
   const handleSubmit = async () => {
     if (!selectedFile && !selectedReplacementId) {
       setSubmitError('Please select an image before submitting.');
       return;
     }
+
     let replacementId = selectedReplacementId;
+
     setIsSubmitting(true);
     setSubmitError(null);
     setUploadedUrl(null);
+
     if (selectedFile && imageMode === "upload") {
       try {
         const data = await uploadImage(selectedFile);
         setUploadedUrl(data.url);
         replacementId = data.media_asset_id;
         setSelectedReplacementId(replacementId); // Use the new media_asset_id for replacement
-        console.log("UPLOAD RESPONSE:", data);
       } catch (error) {
         setSubmitError(error instanceof Error ? error.message : 'Upload failed.');
         setIsSubmitting(false);
@@ -70,9 +65,10 @@ export default function ReplaceImage() {
       }
     }
 
+    // Tightly coupled to API structure, but allows for flexibility in models and media replacement
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/api/${selectedModel}/${selectedModelId}/`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/${selectedModel}/${selectedModelId}/`, //New Models needs APIK changes for PATCH method
         {
           method: 'PATCH',
           headers: {
@@ -130,6 +126,7 @@ export default function ReplaceImage() {
           }}
           selectedId={selectedMediaAssetId}
         />
+
         <div className="text-sm text-slate-600">
           {selectedModel ? `Pick an image` : "No category selected."}
           <div className="grid grid-cols-2 divide-x divide-slate-300 border rounded-md overflow-hidden text-sm text-slate-600">
@@ -155,12 +152,14 @@ export default function ReplaceImage() {
             </button>
           </div>
         </div>
+
         {imageMode === "upload" && (
           <ImportImage
             onChange={(file) => setSelectedFile(file)}
             label="Upload a replacement image"
           />
         )}
+
         {imageMode === "select" && (
           <RetrieveImageList
             modelType={"media"}
@@ -168,7 +167,8 @@ export default function ReplaceImage() {
             selectedId={selectedReplacementId}
           />
         )}
-        {/* Display selected image for reference */}
+
+        {/* Inactive will reduce UI clutter */}
         {selectedFile && imageMode === "upload" && (
            <div className="mt-6">
              <h4 className="text-lg font-medium mb-2">Selected Image:</h4>
@@ -181,6 +181,8 @@ export default function ReplaceImage() {
               />
            </div>
         )}
+
+        {/* Inactive will reduce UI clutter */}
         {imageMode !== null && (
           <div className="flex items-center gap-3">
             <button

--- a/frontend/components/admin/ReplaceImage.tsx
+++ b/frontend/components/admin/ReplaceImage.tsx
@@ -1,0 +1,150 @@
+//query Selected model >> Get {ID, media_asset_id, file_url, file_name}
+//Display file_url as image, for reference
+//insert new selected media_asset_id into Selected model
+//or import new image, which creates new media_asset_id, then insert that ID into Selected model
+//save Selected model to database
+//Display success message to user
+
+'use client';
+
+import React, { useState, useEffect } from "react";
+import { ImportImage } from "@/components/ui/ImportImage";
+import PostImage from "@/components/ui/PostImage";
+import { RetrieveImageList } from "@/components/ui/RetrieveImageList";
+import Image from "next/image";
+
+type ModelType = "media" | "events" | "board-members" | "partners";
+
+export default function ReplaceImage() {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [selectedModel, setSelectedModel] = useState<ModelType | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
+  const [selectedMediaAssetId, setSelectedMediaAssetId] = useState<number | null>(null);
+
+  {/** Expect an image for transfer to storage */}
+  const uploadImage = async (file: File) => {
+    const formData = new FormData();
+    formData.append('image', file);
+
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/media/upload/`,
+      {
+        method: 'POST',
+        body: formData,
+      }
+    );
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => null);
+      throw new Error(errorData?.error || 'Upload failed');
+    }
+
+    return response.json();
+  };
+
+  {/* Response to an image being submitted */}
+  const handleSubmit = async () => {
+    if (!selectedFile) {
+      setSubmitError('Please select an image before submitting.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+    setUploadedUrl(null);
+
+    try {
+      const data = await uploadImage(selectedFile);
+      setUploadedUrl(data.url);
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : 'Upload failed.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+
+  return (
+    <main className="min-h-screen bg-[#fdfdfd] text-[#1a1a1a] p-10 font-sans flex flex-col items-center gap-10">
+      <h3 className="text-1xl mb-6">Replace Image</h3>
+
+      <div className="flex flex-col items-center gap-6">
+        Select where you would like to replace an image:
+        <div className="flex gap-4">
+          {(selectedModel === "media" || selectedModel === null) && (
+            <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            onClick={() => setSelectedModel(prev =>prev === "media" ? null : "media")}>
+              {selectedModel === null ? "Media" : "Cancel"}
+            </button>
+          )}
+          {(selectedModel === "events" || selectedModel === null) && (
+            <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            onClick={() => setSelectedModel(prev =>prev === "events" ? null : "events")}>
+              {selectedModel === null ? "Events" : "Cancel"}
+            </button>
+          )}
+          {(selectedModel === "board-members" || selectedModel === null) && (
+            <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            onClick={() => setSelectedModel(prev =>prev === "board-members" ? null : "board-members")}>
+              {selectedModel === null ? "Board Members" : "Cancel"}
+            </button>
+          )}
+          {(selectedModel === "partners" || selectedModel === null) && (
+            <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            onClick={() => setSelectedModel(prev =>prev === "partners" ? null : "partners")}>
+              {selectedModel === null ? "Partners" : "Cancel"}
+            </button>
+          )}
+        </div>
+        <div className="text-sm text-slate-600">
+          {selectedModel ? `Pick an image` : "No category selected."}
+          <RetrieveImageList modelType={selectedModel} onSelect={(mediaAssetId) => setSelectedMediaAssetId(mediaAssetId)} />
+        </div>
+        {/* Image upload component */}
+        <ImportImage
+             onChange={(file) => setSelectedFile(file)}
+             label="Upload a replacement image"
+        />
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!selectedFile || isSubmitting}
+            className="rounded-md bg-slate-900 text-white px-4 py-2 text-sm font-medium disabled:bg-slate-400"
+          >
+            {isSubmitting ? 'Submitting…' : 'Submit Image'}
+          </button>
+          <span className="text-sm text-slate-700">
+            {selectedFile ? selectedFile.name : 'No file selected.'}
+          </span>
+        </div>
+
+        {submitError && <p className="text-sm text-red-600">{submitError}</p>}
+        {uploadedUrl && (
+          <p className="text-sm text-green-700">
+            Image uploaded successfully: <span className="underline">{uploadedUrl}</span>
+          </p>
+        )}
+
+        {/* Display selected image for reference */}
+        {selectedFile && (
+           <div className="mt-6">
+             <h4 className="text-lg font-medium mb-2">Selected Image:</h4>
+             <Image
+               src={URL.createObjectURL(selectedFile)}
+               alt="Selected for replacement"
+               className="max-w-sm border rounded"
+               width={400}
+               height={300}
+              />
+           </div>
+        )}
+
+      </div>
+
+    </main>
+  );
+}

--- a/frontend/components/ui/ImageDeletionManager.tsx
+++ b/frontend/components/ui/ImageDeletionManager.tsx
@@ -133,43 +133,45 @@ export function ImageDeletionManager({ onClose }: ImageDeletionManagerProps) {
           )}
 
           <div className="overflow-x-auto rounded-xl border border-slate-200">
-            <table className="min-w-full text-left text-sm">
-              <thead>
-                <tr className="bg-slate-50 text-slate-700">
-                  <th className="px-4 py-3">Select</th>
-                  <th className="px-4 py-3">Filename</th>
-                  <th className="px-4 py-3">Upload Date</th>
-                </tr>
-              </thead>
-              <tbody>
-                {imageItems.length === 0 ? (
-                  <tr>
-                    <td colSpan={4} className="px-4 py-10 text-center text-slate-500">
-                      {isLoading ? 'Loading images…' : 'No stored images found.'}
-                    </td>
+            <div className="max-h-96 overflow-y-auto scrollbar-thin scrollbar-thumb-slate-300 scrollbar-track-slate-100">
+              <table className="min-w-full text-left text-sm">
+                <thead className="sticky top-0 bg-slate-50 z-10">
+                  <tr className="text-slate-700">
+                    <th className="px-4 py-3">Select</th>
+                    <th className="px-4 py-3">Filename</th>
+                    <th className="px-4 py-3">Upload Date</th>
                   </tr>
-                ) :
-
-                (imageItems.map((item) => (
-                    <tr key={item.media_asset_id} className="border-t border-slate-100">
-                      <td className="px-4 py-3">
-                        <input
-                          type="checkbox"
-                          checked={selectedIds.includes(item.media_asset_id)}
-                          onChange={() => toggleSelection(item.media_asset_id)}
-                          className="h-4 w-4 rounded border-slate-300 text-slate-900"
-                        />
-                      </td>
-                      <td className="px-4 py-3">{item.file_name}</td>
-                      <td className="px-4 py-3 text-slate-600">
-                        {new Date(item.created_at).toLocaleString()}
+                </thead>
+                <tbody>
+                  {imageItems.length === 0 ? (
+                    <tr>
+                      <td colSpan={3} className="px-4 py-10 text-center text-slate-500">
+                        {isLoading ? 'Loading images…' : 'No stored images found.'}
                       </td>
                     </tr>
-                  ))
-                )}
+                  ) :
 
-              </tbody>
-            </table>
+                  (imageItems.map((item) => (
+                      <tr key={item.media_asset_id} className="border-t border-slate-100">
+                        <td className="px-4 py-3">
+                          <input
+                            type="checkbox"
+                            checked={selectedIds.includes(item.media_asset_id)}
+                            onChange={() => toggleSelection(item.media_asset_id)}
+                            className="h-4 w-4 rounded border-slate-300 text-slate-900"
+                          />
+                        </td>
+                        <td className="px-4 py-3">{item.file_name}</td>
+                        <td className="px-4 py-3 text-slate-600">
+                          {new Date(item.created_at).toLocaleString()}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/components/ui/PostImage.tsx
+++ b/frontend/components/ui/PostImage.tsx
@@ -29,9 +29,10 @@ async function fetchImageById(id: number): Promise<ImageItem> {
 
 type PostImageProps = {
   mediaID: number;
+  className?: string;
 };
 
-export default function PostImage({ mediaID }: PostImageProps) {
+export default function PostImage({ mediaID, className }: PostImageProps) {
   const [image, setImage] = useState<ImageItem | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -58,27 +59,23 @@ export default function PostImage({ mediaID }: PostImageProps) {
   }, [mediaID]);
 
   if (isLoading) {
-    return <div className="p-4">Loading…</div>;
+    return <div>Loading…</div>;
   }
 
   if (error) {
-    return <div className="p-4 text-red-600">Error: {error}</div>;
+    return <div className="text-red-600">Error: {error}</div>;
   }
 
-  if (!image) {
+  if (!image || !image.file_url) {
     return null;
   }
 
   return (
-    <div className="p-4">
-      {image.file_url && (
-        <img
-          src={image.file_url}
-          alt={image.alt_text || image.file_name}
-          className="max-w-md border rounded"
-        />
-      )}
-    </div>
+    <img
+      src={image.file_url}
+      alt={image.alt_text || image.file_name}
+      className={className ?? "w-auto h-auto"}
+    />
   );
 }
 

--- a/frontend/components/ui/PostImage.tsx
+++ b/frontend/components/ui/PostImage.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React, { useEffect, useState } from "react";
+
+type ImageItem = {
+  media_asset_id: number;
+  file_key: string | null;
+  file_url: string | null;
+  file_name: string;
+  file_type: string;
+  alt_text: string;
+  created_at: string;
+};
+
+/**
+ * Fetches a single image by ID from backend/media via MediaDetailView.
+ * Calls GET /api/media/<id>/ to retrieve the MediaAsset record from the database.
+ * Returns the file_url associated with the given ID.
+ */
+async function fetchImageById(id: number): Promise<ImageItem> {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/media/${id}/`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to load image.`);
+  }
+
+  return response.json() as Promise<ImageItem>;
+}
+
+type PostImageProps = {
+  mediaID: number;
+};
+
+export default function PostImage({ mediaID }: PostImageProps) {
+  const [image, setImage] = useState<ImageItem | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!mediaID) return;
+
+    const fetchImage = async () => {
+      setError(null);
+      setIsLoading(true);
+
+      try {
+        const item = await fetchImageById(mediaID);
+        setImage(item);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unable to load image.');
+        setImage(null);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchImage();
+  }, [mediaID]);
+
+  if (isLoading) {
+    return <div className="p-4">Loading…</div>;
+  }
+
+  if (error) {
+    return <div className="p-4 text-red-600">Error: {error}</div>;
+  }
+
+  if (!image) {
+    return null;
+  }
+
+  return (
+    <div className="p-4">
+      {image.file_url && (
+        <img
+          src={image.file_url}
+          alt={image.alt_text || image.file_name}
+          className="max-w-md border rounded"
+        />
+      )}
+    </div>
+  );
+}
+

--- a/frontend/components/ui/PostImage.tsx
+++ b/frontend/components/ui/PostImage.tsx
@@ -12,11 +12,6 @@ type ImageItem = {
   created_at: string;
 };
 
-/**
- * Fetches a single image by ID from backend/media via MediaDetailView.
- * Calls GET /api/media/<id>/ to retrieve the MediaAsset record from the database.
- * Returns the file_url associated with the given ID.
- */
 async function fetchImageById(id: number): Promise<ImageItem> {
   const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/media/${id}/`);
 

--- a/frontend/components/ui/RetrieveImageList.tsx
+++ b/frontend/components/ui/RetrieveImageList.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useState } from "react";
 import PostImage from "./PostImage";
 
-type ModelType = "events" | "board-members" | "partners";
+type ModelType = "media" | "events" | "board-members" | "partners";
 
 type ImageRecord = {
   id: number;
@@ -17,15 +17,18 @@ type ImageRecord = {
 
 type RetrieveImageListProps = {
   modelType: ModelType | null;
+  onSelect?: (mediaAssetId: number) => void;
+  selectedId?: number | null;
 };
 
 const MODEL_API_ENDPOINTS: Record<ModelType, string> = {
   "events": `${process.env.NEXT_PUBLIC_API_URL}/api/events/`,
   "board-members": `${process.env.NEXT_PUBLIC_API_URL}/api/board-members/`,
   "partners": `${process.env.NEXT_PUBLIC_API_URL}/api/partners/`,
+  "media": `${process.env.NEXT_PUBLIC_API_URL}/api/media/`,
 };
 
-export function RetrieveImageList({ modelType }: RetrieveImageListProps) {
+export function RetrieveImageList({ modelType, onSelect, selectedId }: RetrieveImageListProps) {
   const [imageRecords, setImageRecords] = useState<ImageRecord[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,10 +57,21 @@ export function RetrieveImageList({ modelType }: RetrieveImageListProps) {
 
         // Map records based on model type
         const mapped: ImageRecord[] = data.map((record: Record<string, unknown>) => {
+          // Media model: uses media_asset_id as the ID and has file_url directly
+          if (modelType === "media") {
+            return {
+              id: record.media_asset_id as number,
+              media_asset_id: record.media_asset_id as number | null,
+              file_url: record.file_url as string | null,
+              display_name: record.file_name as string | undefined,
+              title: undefined,
+            };
+          }
+
+          // Other models: events, board-members, partners
           const id = modelType === "events" ? (record.event_id as number) :
                      modelType === "board-members" ? (record.board_member_id as number) :
-                     modelType === "partners" ? (record.partner_id as number) :
-                     (record.media_asset_id as number);
+                     (record.partner_id as number);
 
           return {
             id,
@@ -96,20 +110,35 @@ export function RetrieveImageList({ modelType }: RetrieveImageListProps) {
 
   return (
     <div className="grid grid-cols-2 gap-4">
-      {imageRecords.map((record) => (
-        <div key={record.id} className="border rounded p-3">
-          <p className="text-sm font-medium mb-2">
-            {record.title || record.display_name || `ID: ${record.id}`}
-          </p>
-          {record.media_asset_id ? (
-            <PostImage mediaID={record.media_asset_id} />
-          ) : (
-            <div className="w-[300px] h-[300px] flex items-center justify-center bg-slate-100 text-slate-500 text-sm">
-              No image available
-            </div>
-          )}
-        </div>
-      ))}
+      {imageRecords.map((record) => {
+        const mediaAssetId = record.media_asset_id ?? 0;
+        const isSelected = selectedId === mediaAssetId;
+
+        return (
+          <div
+            key={record.id}
+            className={`border rounded p-3 cursor-pointer transition-all ${
+              isSelected
+                ? 'ring-2 ring-blue-500 bg-blue-50'
+                : 'hover:ring-1 hover:ring-slate-300'
+            }`}
+            onClick={() => onSelect?.(mediaAssetId)}
+          >
+            <p className="text-sm font-medium mb-2">
+              {record.title || record.display_name || `ID: ${record.id}`}
+            </p>
+            {record.file_url ? (
+              <img src={record.file_url} alt={record.display_name || 'Image'} className="w-[300px] h-[300px] object-cover rounded" />
+            ) : record.media_asset_id ? (
+              <PostImage mediaID={record.media_asset_id} />
+            ) : (
+              <div className="w-[300px] h-[300px] flex items-center justify-center bg-slate-100 text-slate-500 text-sm">
+                No image available
+              </div>
+            )}
+          </div>
+        );
+      })}
       {imageRecords.length === 0 && !isLoading && (
         <p className="col-span-2 text-sm text-slate-500">No images found.</p>
       )}

--- a/frontend/components/ui/RetrieveImageList.tsx
+++ b/frontend/components/ui/RetrieveImageList.tsx
@@ -87,17 +87,24 @@ export function RetrieveImageList({ modelType }: RetrieveImageListProps) {
   }
 
   if (isLoading) {
-    return <div className="p-4 text-sm text-slate-500">Loading images…</div>;
+    return <div className="text-sm text-slate-500">Loading images…</div>;
   }
 
   if (error) {
-    return <div className="p-4 text-sm text-red-600">Error: {error}</div>;
+    return <div className="text-sm text-red-600">Error: {error}</div>;
   }
 
   return (
     <div className="grid grid-cols-2 gap-4">
       {imageRecords.map((record) => (
         <div key={record.id} className="border rounded p-3">
+          {display_name in record ? (
+            <p className="text-sm font-medium">{record.display_name}</p>
+          ) : record.title ? (
+            <p className="text-sm font-medium">{record.title}</p>
+          ) : (
+            <p className="text-sm font-medium text-slate-500">No title</p>
+          )}
           <PostImage mediaID={record.media_asset_id ?? 0} />
         </div>
       ))}

--- a/frontend/components/ui/RetrieveImageList.tsx
+++ b/frontend/components/ui/RetrieveImageList.tsx
@@ -1,5 +1,3 @@
-//Retrieve image list for preview
-//Accept Modeltype for backend routing
 'use client';
 
 import React, { useEffect, useState } from "react";
@@ -108,12 +106,14 @@ export function RetrieveImageList({ modelType, onSelect, selectedId }: RetrieveI
     return <div className="text-sm text-red-600">Error: {error}</div>;
   }
 
+  /* List for Clarity, Provides Objects given a ModelType */
   return (
     <div className="grid grid-cols-2 gap-4">
       {imageRecords.map((record) => {
         const mediaAssetId = record.media_asset_id ?? 0;
         const isSelected = selectedId === mediaAssetId;
 
+        // Recursively render image from model's media_asset_id
         return (
           <div
             key={record.id}
@@ -127,6 +127,7 @@ export function RetrieveImageList({ modelType, onSelect, selectedId }: RetrieveI
             <p className="text-sm font-medium mb-2">
               {record.title || record.display_name || `ID: ${record.id}`}
             </p>
+
             {record.file_url ? (
               <img src={record.file_url} alt={record.display_name || 'Image'} className="w-[300px] h-[300px] object-cover rounded" />
             ) : record.media_asset_id ? (
@@ -136,6 +137,7 @@ export function RetrieveImageList({ modelType, onSelect, selectedId }: RetrieveI
                 No image available
               </div>
             )}
+
           </div>
         );
       })}

--- a/frontend/components/ui/RetrieveImageList.tsx
+++ b/frontend/components/ui/RetrieveImageList.tsx
@@ -120,7 +120,7 @@ export function RetrieveImageList({ modelType, onSelect, selectedId, selectedMod
           <div
             key={record.id}
             className={`border rounded p-3 cursor-pointer transition-all ${
-              isSelected && isModel
+              (isSelected && isModel) || (isSelected && modelType === "media")
                 ? 'ring-2 ring-blue-500 bg-blue-50'
                 : 'hover:ring-1 hover:ring-slate-300'
             }`}

--- a/frontend/components/ui/RetrieveImageList.tsx
+++ b/frontend/components/ui/RetrieveImageList.tsx
@@ -98,14 +98,16 @@ export function RetrieveImageList({ modelType }: RetrieveImageListProps) {
     <div className="grid grid-cols-2 gap-4">
       {imageRecords.map((record) => (
         <div key={record.id} className="border rounded p-3">
-          {display_name in record ? (
-            <p className="text-sm font-medium">{record.display_name}</p>
-          ) : record.title ? (
-            <p className="text-sm font-medium">{record.title}</p>
+          <p className="text-sm font-medium mb-2">
+            {record.title || record.display_name || `ID: ${record.id}`}
+          </p>
+          {record.media_asset_id ? (
+            <PostImage mediaID={record.media_asset_id} />
           ) : (
-            <p className="text-sm font-medium text-slate-500">No title</p>
+            <div className="w-[300px] h-[300px] flex items-center justify-center bg-slate-100 text-slate-500 text-sm">
+              No image available
+            </div>
           )}
-          <PostImage mediaID={record.media_asset_id ?? 0} />
         </div>
       ))}
       {imageRecords.length === 0 && !isLoading && (

--- a/frontend/components/ui/RetrieveImageList.tsx
+++ b/frontend/components/ui/RetrieveImageList.tsx
@@ -111,9 +111,9 @@ export function RetrieveImageList({ modelType, onSelect, selectedId }: RetrieveI
   return (
     <div className="grid grid-cols-2 gap-4">
       {imageRecords.map((record) => {
-        const mediaAssetId = record.media_asset_id;
+        const mediaAssetId = record.media_asset_id ?? 0;
         const isSelected = selectedId === mediaAssetId;
-        if (!mediaAssetId) return;
+
         return (
           <div
             key={record.id}

--- a/frontend/components/ui/RetrieveImageList.tsx
+++ b/frontend/components/ui/RetrieveImageList.tsx
@@ -1,0 +1,125 @@
+//Retrieve image list for preview
+//Accept Modeltype for backend routing
+'use client';
+
+import React, { useEffect, useState } from "react";
+
+type ModelType = "media" | "events" | "board-members" | "partners";
+
+type ImageRecord = {
+  id: number;
+  media_asset_id: number | null;
+  file_url: string | null;
+  display_name?: string;
+  title?: string;
+};
+
+type RetrieveImageListProps = {
+  modelType: ModelType;
+};
+
+const MODEL_API_ENDPOINTS: Record<ModelType, string> = {
+  "media": `${process.env.NEXT_PUBLIC_API_URL}/api/media/`,
+  "events": `${process.env.NEXT_PUBLIC_API_URL}/api/events/`,
+  "board-members": `${process.env.NEXT_PUBLIC_API_URL}/api/board-members/`,
+  "partners": `${process.env.NEXT_PUBLIC_API_URL}/api/partners/`,
+};
+
+export function RetrieveImageList({ modelType }: RetrieveImageListProps) {
+  const [imageRecords, setImageRecords] = useState<ImageRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchImageRecords = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const endpoint = MODEL_API_ENDPOINTS[modelType];
+        const response = await fetch(endpoint);
+
+        if (!response.ok) {
+          throw new Error('Failed to load image list.');
+        }
+
+        const data = await response.json();
+
+        // Map records based on model type
+        const mapped: ImageRecord[] = data.map((record: Record<string, unknown>) => {
+          const id = modelType === "events" ? (record.event_id as number) :
+                     modelType === "board-members" ? (record.board_member_id as number) :
+                     modelType === "partners" ? (record.partner_id as number) :
+                     (record.media_asset_id as number);
+
+          // For media model, use file_url directly
+          // For other models, we need to fetch the media_asset_id
+          if (modelType === "media") {
+            return {
+              id,
+              media_asset_id: record.media_asset_id as number | null,
+              file_url: record.file_url as string | null,
+              display_name: record.file_name as string | undefined,
+            };
+          }
+
+          return {
+            id,
+            media_asset_id: record.media_asset as number | null,
+            file_url: null,
+            display_name: record.display_name as string | undefined,
+            title: record.title as string | undefined,
+          };
+        });
+
+        setImageRecords(mapped);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unable to load images.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (modelType) {
+      fetchImageRecords();
+    }
+  }, [modelType]);
+
+  if (isLoading) {
+    return <div className="p-4 text-sm text-slate-500">Loading images…</div>;
+  }
+
+  if (error) {
+    return <div className="p-4 text-sm text-red-600">Error: {error}</div>;
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {imageRecords.map((record) => (
+        <div key={record.id} className="border rounded p-3">
+          <p className="text-sm font-medium mb-2">
+            {record.title || record.display_name || `ID: ${record.id}`}
+          </p>
+          {record.file_url ? (
+            <img
+              src={record.file_url}
+              alt={record.display_name || record.title || 'Image'}
+              className="max-w-full h-auto rounded"
+            />
+          ) : record.media_asset_id ? (
+            <p className="text-xs text-slate-400">
+              Media Asset ID: {record.media_asset_id}
+            </p>
+          ) : (
+            <p className="text-xs text-slate-400">No image</p>
+          )}
+        </div>
+      ))}
+      {imageRecords.length === 0 && !isLoading && (
+        <p className="col-span-2 text-sm text-slate-500">No images found.</p>
+      )}
+    </div>
+  );
+}
+
+

--- a/frontend/components/ui/RetrieveImageList.tsx
+++ b/frontend/components/ui/RetrieveImageList.tsx
@@ -17,6 +17,7 @@ type RetrieveImageListProps = {
   modelType: ModelType | null;
   onSelect?: (mediaAssetId: number, modelId: number) => void;
   selectedId?: number | null;
+  selectedModelId?: number | null;
 };
 
 const MODEL_API_ENDPOINTS: Record<ModelType, string> = {
@@ -26,7 +27,7 @@ const MODEL_API_ENDPOINTS: Record<ModelType, string> = {
   "media": `${process.env.NEXT_PUBLIC_API_URL}/api/media/`,
 };
 
-export function RetrieveImageList({ modelType, onSelect, selectedId }: RetrieveImageListProps) {
+export function RetrieveImageList({ modelType, onSelect, selectedId, selectedModelId }: RetrieveImageListProps) {
   const [imageRecords, setImageRecords] = useState<ImageRecord[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -108,17 +109,18 @@ export function RetrieveImageList({ modelType, onSelect, selectedId }: RetrieveI
 
   /* List for Clarity, Provides Objects given a ModelType */
   return (
-    <div className="grid grid-cols-2 gap-4">
+    <div className="grid grid-cols-2 gap-4 justify-items-center">
       {imageRecords.map((record) => {
         const mediaAssetId = record.media_asset_id ?? 0;
         const isSelected = selectedId === mediaAssetId;
+        const isModel = selectedModelId === record.id;
 
         // Recursively render image from model's media_asset_id
         return (
           <div
             key={record.id}
             className={`border rounded p-3 cursor-pointer transition-all ${
-              isSelected
+              isSelected && isModel
                 ? 'ring-2 ring-blue-500 bg-blue-50'
                 : 'hover:ring-1 hover:ring-slate-300'
             }`}
@@ -133,8 +135,10 @@ export function RetrieveImageList({ modelType, onSelect, selectedId }: RetrieveI
             ) : record.media_asset_id ? (
               <PostImage mediaID={record.media_asset_id} />
             ) : (
-              <div className="w-[300px] h-[300px] flex items-center justify-center bg-slate-100 text-slate-500 text-sm">
-                No image available
+              <div className="w-[300px] h-[150px] mx-auto flex items-center justify-center bg-slate-100 text-slate-500 text-sm overflow-hidden rounded">
+                <span className="px-4 text-center leading-snug">
+                  No image available
+                </span>
               </div>
             )}
 

--- a/frontend/components/ui/RetrieveImageList.tsx
+++ b/frontend/components/ui/RetrieveImageList.tsx
@@ -17,7 +17,7 @@ type ImageRecord = {
 
 type RetrieveImageListProps = {
   modelType: ModelType | null;
-  onSelect?: (mediaAssetId: number) => void;
+  onSelect?: (mediaAssetId: number, modelId: number) => void;
   selectedId?: number | null;
 };
 
@@ -111,9 +111,9 @@ export function RetrieveImageList({ modelType, onSelect, selectedId }: RetrieveI
   return (
     <div className="grid grid-cols-2 gap-4">
       {imageRecords.map((record) => {
-        const mediaAssetId = record.media_asset_id ?? 0;
+        const mediaAssetId = record.media_asset_id;
         const isSelected = selectedId === mediaAssetId;
-
+        if (!mediaAssetId) return;
         return (
           <div
             key={record.id}
@@ -122,7 +122,7 @@ export function RetrieveImageList({ modelType, onSelect, selectedId }: RetrieveI
                 ? 'ring-2 ring-blue-500 bg-blue-50'
                 : 'hover:ring-1 hover:ring-slate-300'
             }`}
-            onClick={() => onSelect?.(mediaAssetId)}
+            onClick={() => onSelect?.(mediaAssetId, record.id)}
           >
             <p className="text-sm font-medium mb-2">
               {record.title || record.display_name || `ID: ${record.id}`}

--- a/frontend/components/ui/RetrieveImageList.tsx
+++ b/frontend/components/ui/RetrieveImageList.tsx
@@ -3,8 +3,9 @@
 'use client';
 
 import React, { useEffect, useState } from "react";
+import PostImage from "./PostImage";
 
-type ModelType = "media" | "events" | "board-members" | "partners";
+type ModelType = "events" | "board-members" | "partners";
 
 type ImageRecord = {
   id: number;
@@ -15,11 +16,10 @@ type ImageRecord = {
 };
 
 type RetrieveImageListProps = {
-  modelType: ModelType;
+  modelType: ModelType | null;
 };
 
 const MODEL_API_ENDPOINTS: Record<ModelType, string> = {
-  "media": `${process.env.NEXT_PUBLIC_API_URL}/api/media/`,
   "events": `${process.env.NEXT_PUBLIC_API_URL}/api/events/`,
   "board-members": `${process.env.NEXT_PUBLIC_API_URL}/api/board-members/`,
   "partners": `${process.env.NEXT_PUBLIC_API_URL}/api/partners/`,
@@ -31,6 +31,13 @@ export function RetrieveImageList({ modelType }: RetrieveImageListProps) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    // When null, clear records and show nothing
+    if (modelType === null) {
+      setImageRecords([]);
+      setError(null);
+      return;
+    }
+
     const fetchImageRecords = async () => {
       setIsLoading(true);
       setError(null);
@@ -51,17 +58,6 @@ export function RetrieveImageList({ modelType }: RetrieveImageListProps) {
                      modelType === "board-members" ? (record.board_member_id as number) :
                      modelType === "partners" ? (record.partner_id as number) :
                      (record.media_asset_id as number);
-
-          // For media model, use file_url directly
-          // For other models, we need to fetch the media_asset_id
-          if (modelType === "media") {
-            return {
-              id,
-              media_asset_id: record.media_asset_id as number | null,
-              file_url: record.file_url as string | null,
-              display_name: record.file_name as string | undefined,
-            };
-          }
 
           return {
             id,
@@ -85,6 +81,11 @@ export function RetrieveImageList({ modelType }: RetrieveImageListProps) {
     }
   }, [modelType]);
 
+  // When null, show nothing
+  if (modelType === null) {
+    return null;
+  }
+
   if (isLoading) {
     return <div className="p-4 text-sm text-slate-500">Loading images…</div>;
   }
@@ -97,22 +98,7 @@ export function RetrieveImageList({ modelType }: RetrieveImageListProps) {
     <div className="grid grid-cols-2 gap-4">
       {imageRecords.map((record) => (
         <div key={record.id} className="border rounded p-3">
-          <p className="text-sm font-medium mb-2">
-            {record.title || record.display_name || `ID: ${record.id}`}
-          </p>
-          {record.file_url ? (
-            <img
-              src={record.file_url}
-              alt={record.display_name || record.title || 'Image'}
-              className="max-w-full h-auto rounded"
-            />
-          ) : record.media_asset_id ? (
-            <p className="text-xs text-slate-400">
-              Media Asset ID: {record.media_asset_id}
-            </p>
-          ) : (
-            <p className="text-xs text-slate-400">No image</p>
-          )}
+          <PostImage mediaID={record.media_asset_id ?? 0} />
         </div>
       ))}
       {imageRecords.length === 0 && !isLoading && (


### PR DESCRIPTION
## What does this PR do?
Provides a method to replace images from elements on the website in categories Boardmembers, Events, Partners
<img width="611" height="625" alt="unknown_2026 04 23-22 57" src="https://github.com/user-attachments/assets/19f51131-8af5-4e5f-934f-1662d759d69d" />
## How to test it
http://localhost:3000/admin/dashboard
Click on Events, Board members, or Partners to start image replacement
Will Grab data from database and provide a preview,
Successful submission will replace the image either by upload or selection from storage.


## Checklist
- [ ] Runs locally without errors
- [ ] Migrations included if models changed
- [ ] No `.env` values committed
- [ ] `.gitkeep` files removed from affected directories