### PR TITLE
[SCRUM-83] login validation and error display

### DIFF
--- a/frontend/components/auth/LoginModal.tsx
+++ b/frontend/components/auth/LoginModal.tsx
@@ -19,7 +19,6 @@ export function LoginModal({ onClose }: LoginModalProps) {
   const [password, setPassword] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const [emailTouched, setEmailTouched] = useState(false);
 
   const emailInputRef = useRef<HTMLInputElement>(null);
 
@@ -38,14 +37,16 @@ export function LoginModal({ onClose }: LoginModalProps) {
     return () => window.removeEventListener('keydown', handleEscape);
   }, [onClose]);
 
-  const emailIsValid = isValidEmail(email);
-  const passwordIsValid = password.length > 0;
-  const canSubmit = emailIsValid && passwordIsValid && !isSubmitting;
-  const showEmailError = emailTouched && email.length > 0 && !emailIsValid;
+  const canSubmit = email.length > 0 && password.length > 0 && !isSubmitting;
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     if (!canSubmit) return;
+
+    if (!isValidEmail(email)) {
+      setSubmitError('Please enter a valid email address');
+      return;
+    }
 
     setIsSubmitting(true);
     setSubmitError(null);
@@ -88,16 +89,9 @@ export function LoginModal({ onClose }: LoginModalProps) {
               type="email"
               value={email}
               onChange={(event) => setEmail(event.target.value)}
-              onBlur={() => setEmailTouched(true)}
-              aria-invalid={showEmailError}
               required
               className="px-3 py-2"
             />
-            {showEmailError && (
-              <span className="text-body-sm text-msscc-danger">
-                Please enter a valid email address
-              </span>
-            )}
           </label>
 
           <label className="flex flex-col gap-1">

--- a/frontend/components/auth/LoginModal.tsx
+++ b/frontend/components/auth/LoginModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { useAuth } from '@/context/AuthContext';
+import { isValidEmail } from '@/utils/emailValidation';
 
 interface LoginModalProps {
   onClose: () => void;
@@ -17,6 +18,8 @@ export function LoginModal({ onClose }: LoginModalProps) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [emailTouched, setEmailTouched] = useState(false);
 
   const emailInputRef = useRef<HTMLInputElement>(null);
 
@@ -35,16 +38,24 @@ export function LoginModal({ onClose }: LoginModalProps) {
     return () => window.removeEventListener('keydown', handleEscape);
   }, [onClose]);
 
+  const emailIsValid = isValidEmail(email);
+  const passwordIsValid = password.length > 0;
+  const canSubmit = emailIsValid && passwordIsValid && !isSubmitting;
+  const showEmailError = emailTouched && email.length > 0 && !emailIsValid;
+
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
+    if (!canSubmit) return;
+
     setIsSubmitting(true);
+    setSubmitError(null);
 
     try {
       await login(email, password);
       onClose();
       router.push('/admin/dashboard');
     } catch {
-      // SCRUM-83 will handle error display; for now just stop the spinner
+      setSubmitError('Invalid email or password');
       setIsSubmitting(false);
     }
   };
@@ -77,9 +88,16 @@ export function LoginModal({ onClose }: LoginModalProps) {
               type="email"
               value={email}
               onChange={(event) => setEmail(event.target.value)}
+              onBlur={() => setEmailTouched(true)}
+              aria-invalid={showEmailError}
               required
               className="px-3 py-2"
             />
+            {showEmailError && (
+              <span className="text-body-sm text-msscc-danger">
+                Please enter a valid email address
+              </span>
+            )}
           </label>
 
           <label className="flex flex-col gap-1">
@@ -93,9 +111,13 @@ export function LoginModal({ onClose }: LoginModalProps) {
             />
           </label>
 
+          {submitError && (
+            <span className="text-body-sm text-msscc-danger">{submitError}</span>
+          )}
+
           <button
             type="submit"
-            disabled={isSubmitting}
+            disabled={!canSubmit}
             className="mt-2 rounded-sm bg-msscc-teal px-4 py-2 text-btn tracking-btn text-msscc-white transition-colors hover:bg-msscc-teal-dark disabled:opacity-60"
           >
             {isSubmitting ? 'Logging in…' : 'Log In'}

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -15,6 +15,9 @@ interface AuthProviderProps {
 }
 
 // Dev User Details
+// TODO(pre-delivery): Remove the dev auto-login toggle before handing the
+// product to MSSCC. The DEV_AUTO_LOGIN block, DEV_USER constant, and the
+// NEXT_PUBLIC_DEV_AUTO_LOGIN env var should all go.
 const DEV_AUTO_LOGIN = process.env.NEXT_PUBLIC_DEV_AUTO_LOGIN === 'true';
 
 const DEV_USER: UserPayload = {

--- a/frontend/utils/emailValidation.ts
+++ b/frontend/utils/emailValidation.ts
@@ -1,0 +1,6 @@
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Returns true if the value is a syntactically valid email address. */
+export function isValidEmail(value: string): boolean {
+  return EMAIL_REGEX.test(value);
+}


### PR DESCRIPTION
## What does this PR do?
- Email format validated against regex at submit time (SCRUM-338)
- Password requires at least 1 character
- Submit button disabled until both fields are non-empty
- 'Please enter a valid email address' shown for invalid email format
- 'Invalid email or password' shown on 401 from backend
- Error messages styled with msscc-danger
- New isValidEmail() utility in frontend/utils/emailValidation.ts

## How to test it
1. Open the login modal from the banner
2. Verify Log In button is disabled until both email and password fields have content
3. Enter an invalid email (e.g. "foo@bar") and any password — clicking Log In should show "Please enter a valid email address" without making a request
4. Enter a valid email format with wrong credentials — should show "Invalid email or password" after the request returns 401
5. Enter valid credentials — should redirect to /admin/dashboard

## Checklist
- [x] Runs locally without errors
- [x] Migrations included if models changed
- [x] No `.env` values committed
- [x] `.gitkeep` files removed from affected directories