### PR TITLE
[SCRUM 87] password reset backend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,5 +26,9 @@ S3_BUCKET=
 S3_ENDPOINT_URL=
 S3_REGION=auto
 
-# === DeepL API ===
-DEEPL_API_KEY=
+# === Resend (email) ===
+RESEND_API_KEY=
+RESEND_FROM_EMAIL=onboarding@resend.dev
+FRONTEND_URL=http://localhost:3000
+RESEND_DEV_ALERT_EMAIL=
+

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -33,3 +33,10 @@ class AdminUserSerializer(serializers.ModelSerializer):
             "is_executive",
             "permissions",
         ]
+
+class PasswordResetConfirmSerializer(serializers.Serializer):
+    """Validates input for password reset confirmation."""
+
+    uid = serializers.CharField()
+    token = serializers.CharField()
+    new_password = serializers.CharField(min_length=8)

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -8,6 +8,7 @@ from accounts.views import (
     get_admin,
     update_permissions,
     password_reset_request,
+    password_reset_confirm,
 )
 
 urlpatterns = [
@@ -15,4 +16,5 @@ urlpatterns = [
     path("token/refresh/", TokenRefreshView.as_view(), name="auth-token-refresh"),
     path("logout/", LogoutView.as_view(), name="auth-logout"),
     path("password-reset/", password_reset_request, name="auth-password-reset"),
+    path("password-reset/confirm/", password_reset_confirm, name="auth-password-reset-confirm"),
 ]

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -7,10 +7,12 @@ from accounts.views import (
     list_admins,
     get_admin,
     update_permissions,
+    password_reset_request,
 )
 
 urlpatterns = [
     path("login/", AdminTokenObtainPairView.as_view(), name="auth-login"),
     path("token/refresh/", TokenRefreshView.as_view(), name="auth-token-refresh"),
     path("logout/", LogoutView.as_view(), name="auth-logout"),
+    path("password-reset/", password_reset_request, name="auth-password-reset"),
 ]

--- a/backend/accounts/utils.py
+++ b/backend/accounts/utils.py
@@ -1,0 +1,41 @@
+import resend
+from django.conf import settings
+import logging
+
+logger = logging.getLogger(__name__)
+
+def send_password_reset_email(to_email: str, reset_link: str) -> None:
+    """Send a password reset email via Resend. Logs and alerts on failure."""
+    resend.api_key = settings.RESEND_API_KEY
+
+    try:
+        resend.Emails.send({
+            "from": settings.RESEND_FROM_EMAIL,
+            "to": to_email,
+            "subject": "MSSCC Admin Password Reset",
+            "html": (
+                f"<p>You requested a password reset for your MSSCC admin account.</p>"
+                f"<p>Click the link below to set a new password. This link expires in 1 hour.</p>"
+                f'<p><a href="{reset_link}">Reset your password</a></p>'
+                f"<p>If you didn't request this, you can ignore this email.</p>"
+            ),
+        })
+    except Exception as exc:
+        logger.error("Resend send failed for %s: %s", to_email, exc)
+        if not settings.RESEND_DEV_ALERT_EMAIL:
+            return
+        error_message = str(exc)
+        try:
+            logger.info("Sending alert to: %s", settings.RESEND_DEV_ALERT_EMAIL)
+            resend.Emails.send({
+                "from": settings.RESEND_FROM_EMAIL,
+                "to": settings.RESEND_DEV_ALERT_EMAIL,
+                "subject": "[MSSCC dev] Password reset email failed",
+                "html": (
+                    f"<p>Failed to send password reset to: {to_email}</p>"
+                    f"<p>Error: {error_message}</p>"
+                    f"<p>Reset link was: {reset_link}</p>"
+                ),
+            })
+        except Exception as alert_exc:
+            logger.error("Resend alert send also failed: %s", alert_exc)

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -7,14 +7,19 @@ from rest_framework.views import APIView
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from accounts.models import AdminUser
-from accounts.serializers import AdminTokenObtainPairSerializer, AdminUserSerializer
+from accounts.utils import send_password_reset_email
+from accounts.serializers import (
+    AdminTokenObtainPairSerializer,
+    AdminUserSerializer,
+    PasswordResetConfirmSerializer,
+)
 
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 from django.conf import settings
-
-from accounts.utils import send_password_reset_email
+from django.utils.encoding import force_str
+from django.utils.http import urlsafe_base64_decode
 
 
 class AdminTokenObtainPairView(TokenObtainPairView):
@@ -79,3 +84,34 @@ def password_reset_request(request):
     return Response(
         {"detail": "If an account exists with that email, a reset link has been sent."}
     )
+
+@api_view(["POST"])
+def password_reset_confirm(request):
+    """Validate the reset token and set a new password. Token is single-use."""
+    serializer = PasswordResetConfirmSerializer(data=request.data)
+    if not serializer.is_valid():
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    uid = serializer.validated_data["uid"]
+    token = serializer.validated_data["token"]
+    new_password = serializer.validated_data["new_password"]
+
+    try:
+        user_id = force_str(urlsafe_base64_decode(uid))
+        user = AdminUser.objects.get(pk=user_id)
+    except (ValueError, AdminUser.DoesNotExist):
+        return Response(
+            {"detail": "Invalid or expired reset link."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if not default_token_generator.check_token(user, token):
+        return Response(
+            {"detail": "Invalid or expired reset link."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    user.set_password(new_password)
+    user.save()
+
+    return Response({"detail": "Password reset successfully."})

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -9,6 +9,13 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from accounts.models import AdminUser
 from accounts.serializers import AdminTokenObtainPairSerializer, AdminUserSerializer
 
+from django.contrib.auth.tokens import default_token_generator
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from django.conf import settings
+
+from accounts.utils import send_password_reset_email
+
 
 class AdminTokenObtainPairView(TokenObtainPairView):
     """Return access and refresh tokens for valid admin credentials."""
@@ -49,3 +56,26 @@ def update_permissions(request, admin_id):
     admin.permissions_data = request.data["permissions"]
     admin.save()
     return Response({"success": True})
+
+@api_view(["POST"])
+def password_reset_request(request):
+    """Send a password reset link to the email if an account exists. Always returns 200."""
+    email = request.data.get("email", "").strip()
+
+    if email:
+        try:
+            user = AdminUser.objects.get(email=email)
+            token = default_token_generator.make_token(user)
+            uid = urlsafe_base64_encode(force_bytes(user.pk))
+            reset_link = f"{settings.FRONTEND_URL}/reset-password?token={token}&uid={uid}"
+
+            try:
+                send_password_reset_email(user.email, reset_link)
+            except Exception:
+                pass
+        except AdminUser.DoesNotExist:
+            pass
+
+    return Response(
+        {"detail": "If an account exists with that email, a reset link has been sent."}
+    )

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -180,3 +180,8 @@ STORAGES = {
     },
 }
 
+# Resend Configuration
+RESEND_API_KEY = os.getenv("RESEND_API_KEY")
+RESEND_FROM_EMAIL = os.getenv("RESEND_FROM_EMAIL")
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+RESEND_DEV_ALERT_EMAIL = os.getenv("RESEND_DEV_ALERT_EMAIL")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ sqlparse==0.5.5
 tzdata==2025.3
 django-storages==1.14.4
 boto3==1.34.0
+resend==2.4.0

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,3 +1,6 @@
 NEXT_PUBLIC_API_URL=http://localhost:8000
 # Set to 'true' to bypass login during dev. Leave unset or 'false' otherwise.
 NEXT_PUBLIC_DEV_AUTO_LOGIN=false
+
+# === DeepL API ===
+DEEPL_API_KEY=


### PR DESCRIPTION
## What this does
- Password reset request endpoint with Resend integration (SCRUM-341)
- Password reset confirmation endpoint with single-use token validation (SCRUM-342)
- New utility module backend/accounts/utils.py for email sending
- Dev email alerts to RESEND_DEV_ALERT_EMAIL when a primary send fails — useful while we're on Resend's onboarding sender which can only deliver to the account email

## Notes
- New env vars: RESEND_API_KEY, RESEND_FROM_EMAIL, RESEND_DEV_ALERT_EMAIL, FRONTEND_URL — see updated .env.example
- New dependency: resend==2.4.0 — run `pip install -r requirements.txt --break-system-packages` after pulling
- Production cutover requires verifying msscc1.org on a Resend account and updating RESEND_FROM_EMAIL accordingly. Until then, sends only work to the email associated with the dev Resend account.
- Reset email link points at /reset-password — that page is built in SCRUM-146 / SCRUM-343, so the link won't render anything yet

## How to test it
A test superuser already exists with the dev mailbox email. Request credentials from Ulisses if you want to test against your own user.

Trigger a reset email — should return 200 and an email lands in the dev mailbox:
```bash
curl -X POST http://localhost:8000/api/auth/password-reset/ \
  -H "Content-Type: application/json" \
  -d '{"email": "msscc.scrumlords.dev@gmail.com"}'
```

Trigger the failure path — should return 200 (no user enumeration) and an alert lands in the dev mailbox:
```bash
curl -X POST http://localhost:8000/api/auth/password-reset/ \
  -H "Content-Type: application/json" \
  -d '{"email": "testemail@test.com"}'
```

Confirm the reset using token + uid from the email link — should return 200:
```bash
curl -X POST http://localhost:8000/api/auth/password-reset/confirm/ \
  -H "Content-Type: application/json" \
  -d '{"uid": "<uid>", "token": "<token>", "new_password": "newpass123"}'
```

Verify single-use — running the same confirm curl a second time should return 400.

Verify the new password works:
```bash
curl -X POST http://localhost:8000/api/auth/login/ \
  -H "Content-Type: application/json" \
  -d '{"email": "msscc.scrumlords.dev@gmail.com", "password": "newpass123"}'
```


## Checklist
- [x] Runs locally without errors
- [x] Migrations included if models changed
- [x] No `.env` values committed
- [x] `.gitkeep` files removed from affected directories