### PR TITLE
[SCRUM-146] frontend reset password pages

### DIFF
--- a/frontend/app/forgot-password/page.tsx
+++ b/frontend/app/forgot-password/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState } from 'react';
+
+import { isValidEmail } from '@/utils/emailValidation';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!isValidEmail(email)) {
+      setError('Please enter a valid email address');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await fetch(`${API_BASE_URL}/api/auth/password-reset/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      setSubmitted(true);
+    } catch {
+      setError('Something went wrong. Please try again.');
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto flex min-h-[60vh] max-w-md flex-col justify-center px-4 py-10">
+      <h1 className="mb-6">Forgot password</h1>
+
+      {submitted ? (
+        <p>If an account exists with that email, a reset link has been sent.</p>
+      ) : (
+        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-body-sm">Email</span>
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              disabled={isSubmitting}
+              className="px-3 py-2"
+            />
+          </label>
+
+          {error && (
+            <span className="text-body-sm text-msscc-danger">{error}</span>
+          )}
+
+          <button
+            type="submit"
+            disabled={email.length === 0 || isSubmitting}
+            className="mt-2 rounded-sm bg-msscc-teal px-4 py-2 text-btn tracking-btn text-msscc-white transition-colors hover:bg-msscc-teal-dark disabled:opacity-60"
+          >
+            {isSubmitting ? 'Sending…' : 'Send reset link'}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
+
+export default function ResetPasswordPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const uid = searchParams.get('uid');
+  const token = searchParams.get('token');
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!success) return;
+    const timer = setTimeout(() => router.push('/'), 3000);
+    return () => clearTimeout(timer);
+  }, [success, router]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!uid || !token) {
+      setError('Invalid or expired reset link.');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match.');
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setError('Password must be at least 8 characters.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/auth/password-reset/confirm/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uid, token, new_password: newPassword }),
+      });
+
+      if (!response.ok) {
+        setError('Invalid or expired reset link.');
+        setIsSubmitting(false);
+        return;
+      }
+
+      setSuccess(true);
+    } catch {
+      setError('Something went wrong. Please try again.');
+      setIsSubmitting(false);
+    }
+  };
+
+  const canSubmit =
+    newPassword.length > 0 && confirmPassword.length > 0 && !isSubmitting;
+
+  return (
+    <div className="mx-auto flex min-h-[60vh] max-w-md flex-col justify-center px-4 py-10">
+      <h1 className="mb-6">Reset password</h1>
+
+      {success ? (
+        <p>Password reset successfully. Redirecting to home…</p>
+      ) : (
+        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-body-sm">New password</span>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(event) => setNewPassword(event.target.value)}
+              required
+              disabled={isSubmitting}
+              className="px-3 py-2"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-body-sm">Confirm new password</span>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              required
+              disabled={isSubmitting}
+              className="px-3 py-2"
+            />
+          </label>
+
+          {error && (
+            <span className="text-body-sm text-msscc-danger">{error}</span>
+          )}
+
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="mt-2 rounded-sm bg-msscc-teal px-4 py-2 text-btn tracking-btn text-msscc-white transition-colors hover:bg-msscc-teal-dark disabled:opacity-60"
+          >
+            {isSubmitting ? 'Resetting…' : 'Reset password'}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/auth/LoginModal.tsx
+++ b/frontend/components/auth/LoginModal.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
 import { useAuth } from '@/context/AuthContext';
 import { isValidEmail } from '@/utils/emailValidation';
@@ -108,6 +109,14 @@ export function LoginModal({ onClose }: LoginModalProps) {
           {submitError && (
             <span className="text-body-sm text-msscc-danger">{submitError}</span>
           )}
+
+          <Link
+            href="/forgot-password"
+            onClick={onClose}
+            className="text-body-sm text-msscc-teal hover:underline"
+          >
+            Forgot password?
+          </Link>
 
           <button
             type="submit"


### PR DESCRIPTION
## What this does
- Forgot password page at /forgot-password — submits email and shows confirmation message (SCRUM-343)
- Reset password page at /reset-password — reads uid and token from URL, validates passwords match, calls confirm endpoint, redirects to home after 3 seconds on success (SCRUM-343)
- Added "Forgot password?" link to LoginModal that routes to the forgot password page

## Notes
- Pages are English-only since they're admin-context, matching the rest of the admin UI

## How to test it
1. Open the login modal, click "Forgot password?" — should navigate to /forgot-password and dismiss the modal
2. Submit your email — confirmation message should appear
3. Open the reset email, click the link — should land on /reset-password
4. Submit mismatched passwords — should show "Passwords do not match"
5. Submit matching valid passwords — should show success message and redirect to home after 3 seconds
6. Click the same email link again, try to reset — should show "Invalid or expired reset link"
7. Verify new password works via the login modal

## Checklist
- [x] Runs locally without errors
- [x] Migrations included if models changed
- [x] No `.env` values committed
- [x] `.gitkeep` files removed from affected directories